### PR TITLE
Harden exec_sublime_python helpers, add helper tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: SublimeText/UnitTesting/actions/setup@v1
         with:
           sublime-text-version: 4

--- a/README.md
+++ b/README.md
@@ -84,9 +84,18 @@ resources. Agents should read it as their primary reference.
 
 ## Tests
 
-One smoke test that pings the MCP endpoint over loopback. Runs inside
-Sublime Text via the [UnitTesting](https://github.com/SublimeText/UnitTesting)
-package, both locally and in CI.
+Two suites, both running inside Sublime Text via the
+[UnitTesting](https://github.com/SublimeText/UnitTesting) package:
+
+- [`tests/test_smoke.py`](tests/test_smoke.py) pings the MCP endpoint
+  over loopback and confirms `initialize` round-trips.
+- [`tests/test_helpers.py`](tests/test_helpers.py) covers the helper
+  surface exposed inside `exec_sublime_python`: response shape (outer
+  `ok` dropped, `error` populated on exception), `scope_at` vs
+  `scope_at_test` on extension-less files, `resolve_position`'s
+  overflow / clamped matrix, `run_syntax_tests` via
+  `sublime_api.run_syntax_test` and the build-panel fallback, and
+  `_to_resource_path` edge cases.
 
 ### Locally
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -9,7 +9,7 @@ Security: binds 127.0.0.1 only; exec'ing arbitrary Python is equivalent to
 an open console. Do not expose the port beyond localhost.
 """
 
-import contextlib
+import builtins as _builtins
 import io
 import json
 import threading
@@ -40,19 +40,42 @@ knows about, etc.
 
 ## What's in scope
 
-The snippet runs on ST's async worker thread (`sublime.set_timeout_async`),
-so it can wait on file loads and build panels without deadlocking ST's
-UI. The following names are preloaded:
+The snippet runs on a dedicated daemon thread so it can wait on file
+loads and build panels without deadlocking ST's UI. Most of the ST
+API is thread-safe from any thread; for the few operations that
+require the main UI thread (e.g. `TextCommand` edit tokens), use
+`sublime.set_timeout(lambda: ..., 0)` inside the snippet and poll.
+The following names are preloaded:
 
 - `sublime`, `sublime_plugin` — the ST Python API modules.
 - `scope_at(path, row, col) -> str` — opens the file, returns
   `view.scope_name` at the 0-indexed (row, col). Rows and cols are
   0-indexed, matching ST's API (a syntax-test assertion on line 181
-  col 9 corresponds to `row=180, col=8`).
-- `run_syntax_tests(path) -> dict` — opens the file and runs the
-  "Syntax Tests" build variant. Returns
-  `{"ok": bool, "summary": str, "output": str}`. `ok` is True when
-  the build panel ends with "assertions passed" and no failures.
+  col 9 corresponds to `row=180, col=8`). **Use `scope_at_test` for
+  files with no extension. `scope_at` does not parse the
+  `# SYNTAX TEST` header and will silently return `text.plain` when
+  ST can't infer the syntax from the file name** — a common landmine
+  with `syntax_test_*` files.
+- `scope_at_test(path, row, col) -> str` — like `scope_at`, but
+  parses the `SYNTAX TEST "Packages/..."` header on line 0 and
+  assigns that syntax to the view before sampling the scope. The
+  right helper for extension-less syntax-test files.
+- `resolve_position(path, row, col, syntax_path=None) -> dict` —
+  returns the full position disambiguation for `(row, col)`. See
+  "text_point overflow" below. Optional `syntax_path` calls
+  `assign_syntax_and_wait` on the view first.
+- `run_syntax_tests(path, timeout=30.0) -> dict` — returns
+  `{"ok": bool, "summary": str, "output": str, "failures": list[str]}`.
+  `ok` is True when all assertions passed. `failures` is one entry
+  per failed assertion with ST's own diagnostic (file:row:col,
+  "error: scope does not match", then the expected/actual snippet).
+  Primary path uses `sublime_api.run_syntax_test`, which returns
+  synchronously from a private ST API; falls back to the "Syntax
+  Tests" build variant for paths outside `sublime.packages_path()`.
+  The API path requires the file to live under Packages/ (either as
+  an absolute path rooted there, or the `Packages/...` resource
+  form); syntect-style investigations typically symlink the repo's
+  test dir into Packages/ for this reason.
 - `reload_syntax(resource_path) -> None` — force-reloads a
   `.sublime-syntax` resource. Useful when ST cached an older version
   (e.g. after an external edit via symlink).
@@ -60,17 +83,54 @@ UI. The following names are preloaded:
   `sublime.find_resources(pattern)`.
 - `open_view(path) -> sublime.View` — opens the file, polls
   `is_loading()` up to 5 s, returns the View.
+- `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None`
+  — assigns a syntax and best-effort waits for tokenisation to touch
+  point 0. Stage 1 (wait for the syntax setting to apply) is
+  deterministic; stage 2 (tokenisation) is best-effort — ST has no
+  public tokenisation-complete signal. For large files, re-read
+  `scope_name` after use rather than trusting the helper.
+
+## text_point overflow
+
+`view.text_point(row, col)` does **not** clamp `col` to the row's
+content length when the column overflows past EOL. Instead, it
+advances linearly into subsequent rows' offsets. Example:
+
+```python
+# Row 71 is 28 chars + "\\n". Asking for col 29:
+view.text_point(71, 29)    # => 2809
+view.rowcol(2809)          # => (72, 0)  ← overflowed to next row
+```
+
+This is load-bearing for ST's `syntax_test` framework: past-EOL
+assertion columns evaluate against the corresponding column on the
+*next* line, which is why some "impossible" past-EOL assertions
+actually pass on ST. Use `resolve_position` to surface this
+explicitly — its `overflow` (wrapped into a later row) and `clamped`
+(request was past EOF; point == view.size()) fields disambiguate the
+cases. **`overflow` and `clamped` are mutually exclusive**: if the
+request is past EOF, `clamped` wins and `overflow` stays False
+regardless of row wrapping.
 
 ## Output protocol
 
 Anything you `print(...)` is captured and returned as `output`. If you
 assign a value to `_`, its `repr` is returned as `result`. Exceptions
 are caught, formatted, and returned as `error` (with whatever was
-printed up to that point still in `output`). The response shape is:
+printed up to that point still in `output`). Only `print(...)` is
+captured — direct writes to `sys.stderr` / `sys.stdout` are not,
+because the capture is a per-call `print` override rather than a
+global stream redirect (needed for thread-safety under concurrent
+requests). The response shape is:
 
 ```
-{"ok": bool, "output": str, "result": str|null, "error": str|null}
+{"output": str, "result": str|null, "error": str|null}
 ```
+
+`error is null` means the snippet ran to completion. Note that some
+helpers return their own dict containing an `ok` key (e.g.
+`run_syntax_tests(...)["ok"]` — "did all assertions pass?"); that
+inner `ok` is unrelated to the absence of `error` at the top level.
 
 ## Recipes
 
@@ -81,14 +141,65 @@ printed up to that point still in `output`). The response shape is:
 print(scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8))
 ```
 
+### Scope on an extension-less syntax-test file
+
+```python
+# File has no extension; `scope_at` would return "text.plain".
+# scope_at_test parses `# SYNTAX TEST "Packages/..."` on line 0.
+print(scope_at_test("/path/to/syntax_test_git_config", 71, 28))
+```
+
+### Resolve a past-EOL position
+
+```python
+r = resolve_position("/path/to/syntax_test_git_config", 71, 29,
+                     syntax_path="Packages/Git Formats/Git Config.sublime-syntax")
+if r["overflow"]:
+    print("wrapped into row", r["actual"][0], "col", r["actual"][1])
+elif r["clamped"]:
+    print("past EOF; point clamped to", r["point"])
+print("scope:", r["scope"])
+```
+
 ### Run syntax tests on a file
 
 ```python
 r = run_syntax_tests("/path/to/Packages/C#/tests/syntax_test_Generics.cs")
 print(r["summary"])
-if not r["ok"]:
-    print(r["output"])
+for msg in r["failures"]:
+    print(msg)
 ```
+
+### Compare a syntect baseline failure against ST
+
+The three-primitive workflow for "is this a syntect bug or a harness-
+semantics divergence?". Each step answers a distinct question:
+
+```python
+# 1. What scope does ST actually report at the failing position?
+print(scope_at_test("/path/to/Packages/Git Formats/tests/syntax_test_git_config", 71, 28))
+
+# 2. Did syntect and ST even agree on which row/col to sample?
+#    (past-EOL overflow is a common hidden source of divergence)
+r = resolve_position(
+    "/path/to/Packages/Git Formats/tests/syntax_test_git_config", 71, 29,
+    syntax_path="Packages/Git Formats/Git Config.sublime-syntax",
+)
+print("overflow:", r["overflow"], "clamped:", r["clamped"], "actual:", r["actual"])
+
+# 3. What does ST's own assertion runner say about this file?
+r = run_syntax_tests("/path/to/Packages/Git Formats/tests/syntax_test_git_config")
+if r["ok"]:
+    print("ST passes all assertions → syntect harness diverges from ST")
+else:
+    print("ST fails these too → test data itself has the issue:")
+    for msg in r["failures"]:
+        print(msg)
+```
+
+Note: `run_syntax_tests(...)["ok"]` is the inner "all assertions
+passed" signal; unrelated to the top-level `error is None` success
+check on the MCP response.
 
 ### Reload a syntax file after an external edit
 
@@ -113,19 +224,40 @@ print(v.file_name(), v.sel()[0], v.scope_name(v.sel()[0].a))
 ## Gotchas
 
 - Hard timeout per call is 60 s.
-- The snippet runs on ST's async worker thread. Most of the ST API is
-  thread-safe, but a few mutating operations (`TextCommand` edit tokens)
-  require the main thread — call `sublime.set_timeout(lambda: ..., 0)`
-  from within the snippet if you need that, and poll for completion.
-- File paths must be absolute for `scope_at` / `run_syntax_tests` /
-  `open_view`. `find_resources` uses ST's `Packages/...` virtual paths.
-- `run_syntax_tests` is async inside ST; this helper polls the build
-  panel for up to ~15 s for completion.
+- The snippet runs on a dedicated daemon thread (not ST's async
+  worker and not the main UI thread). Most of the ST API is
+  thread-safe, but a few mutating operations (`TextCommand` edit
+  tokens) require the main thread — call
+  `sublime.set_timeout(lambda: ..., 0)` from within the snippet if
+  you need that, and poll for completion.
+- File paths must be absolute for `scope_at` / `scope_at_test` /
+  `resolve_position` / `run_syntax_tests` / `open_view`.
+  `find_resources` uses ST's `Packages/...` virtual paths, and
+  `run_syntax_tests` accepts that form too.
+- `run_syntax_tests` prefers the private `sublime_api.run_syntax_test`
+  (synchronous, structured result) for files under Packages/ and
+  falls back to the "Syntax Tests" build variant otherwise. The
+  fallback polls the build panel for up to `timeout` seconds.
+- The primary `run_syntax_tests` path uses `sublime_api.run_syntax_test`,
+  which is a **private, undocumented** ST API. ST has changed private
+  APIs before; if this one disappears the build-panel fallback takes
+  over automatically, but callers will see a behaviour shift (timing,
+  panel-scrape edge cases) without warning.
 """
 
 
 HELPERS_SOURCE = r'''
+import os as _os
+import re as _re
 import time as _time
+
+try:
+    import sublime_api as _sublime_api
+except ImportError:
+    _sublime_api = None
+
+
+_SYNTAX_TEST_HEADER = _re.compile(r'SYNTAX TEST\s+"([^"]+)"')
 
 
 def open_view(path, timeout=5.0):
@@ -136,6 +268,17 @@ def open_view(path, timeout=5.0):
         _time.sleep(0.02)
     if view.is_loading():
         raise TimeoutError("open_view: still loading after %ss: %s" % (timeout, path))
+    # `is_loading()` tracks file load, not tokenisation. On cold ST the
+    # initial tokeniser pass lags file-load; `scope_name(0)` returns ""
+    # until it completes. Poll briefly for the first scope to appear so
+    # callers that sample scopes immediately after open don't race.
+    # Fall through without raising — a still-empty scope after 1 s is
+    # tolerable; callers who need stricter guarantees can re-read.
+    tokenise_deadline = _time.time() + 1.0
+    while _time.time() < tokenise_deadline:
+        if view.scope_name(0):
+            break
+        _time.sleep(0.02)
     window.focus_view(view)
     return view
 
@@ -144,6 +287,82 @@ def scope_at(path, row, col):
     view = open_view(path)
     point = view.text_point(row, col)
     return view.scope_name(point).rstrip()
+
+
+def assign_syntax_and_wait(view, resource_path, timeout=2.0):
+    # ST exposes no public tokenisation-complete signal. Stage 1 waits for
+    # view.settings()["syntax"] to reflect the requested path (usually one
+    # tick, but guards against a typo landing silently). Stage 2 is a
+    # best-effort poll for tokenisation to touch point 0 — it's a smarter
+    # sleep, not a correctness guarantee. Callers with large files should
+    # re-read scope_name after use rather than trust this helper.
+    # Fallback for views whose initial scope is empty (mid-load); in
+    # practice callers come through open_view and this branch doesn't fire,
+    # but it prevents stage 2 from exiting on the first populated scope
+    # regardless of syntax.
+    pre_scope = view.scope_name(0) or "text.plain "
+    view.assign_syntax(resource_path)
+    stage1_deadline = _time.time() + timeout
+    while _time.time() < stage1_deadline:
+        if view.settings().get("syntax") == resource_path:
+            break
+        _time.sleep(0.02)
+    else:
+        raise TimeoutError(
+            "assign_syntax_and_wait: syntax setting not applied in %ss" % timeout
+        )
+    stage2_deadline = _time.time() + 0.2
+    while _time.time() < stage2_deadline:
+        if view.scope_name(0) != pre_scope:
+            return
+        _time.sleep(0.02)
+    # Fall through — caller gets whatever scope is current.
+
+
+def _parse_syntax_test_header(view):
+    # First line of every ST syntax-test file carries
+    #   <comment> SYNTAX TEST "Packages/.../Some.sublime-syntax"
+    # where <comment> varies (#, //, <!--, ;, --, etc). Grab the first
+    # quoted substring after the marker.
+    line_region = view.line(0)
+    first_line = view.substr(line_region)
+    m = _SYNTAX_TEST_HEADER.search(first_line)
+    if not m:
+        raise ValueError(
+            "no SYNTAX TEST header on line 0: %r" % first_line[:120]
+        )
+    return m.group(1)
+
+
+def scope_at_test(path, row, col):
+    view = open_view(path)
+    resource_path = _parse_syntax_test_header(view)
+    assign_syntax_and_wait(view, resource_path)
+    point = view.text_point(row, col)
+    return view.scope_name(point).rstrip()
+
+
+def resolve_position(path, row, col, syntax_path=None):
+    view = open_view(path)
+    if syntax_path is not None:
+        assign_syntax_and_wait(view, syntax_path)
+    point = view.text_point(row, col)
+    real_row, real_col = view.rowcol(point)
+    size = view.size()
+    clamped = point == size
+    # `>` rather than `!=`: text_point is monotonically non-decreasing so
+    # behaviourally equivalent today, but the stronger invariant defends
+    # against future inputs that resolve to a *smaller* row (negative
+    # rows, CRLF edge cases) — those would be bugs, not overflows.
+    overflow = real_row > row and not clamped
+    return {
+        "point": point,
+        "requested": [row, col],
+        "actual": [real_row, real_col],
+        "scope": view.scope_name(point).rstrip(),
+        "overflow": overflow,
+        "clamped": clamped,
+    }
 
 
 def reload_syntax(resource_path):
@@ -163,61 +382,209 @@ def find_resources(pattern):
     return list(sublime.find_resources(pattern))
 
 
-def run_syntax_tests(path, poll_timeout=15.0):
+def _to_resource_path(path):
+    # sublime_api.run_syntax_test only accepts resource paths of the form
+    # "Packages/...". For abs paths under sublime.packages_path(), strip
+    # the prefix and re-prepend "Packages". Returns None if the path
+    # isn't under the Packages tree; caller decides whether to fall back.
+    if path.startswith("Packages/") or path.startswith("Packages\\"):
+        return path
+    packages_root = sublime.packages_path()
+    abs_path = _os.path.abspath(path)
+    try:
+        rel = _os.path.relpath(abs_path, packages_root)
+    except ValueError:
+        return None
+    if rel.startswith("..") or _os.path.isabs(rel):
+        return None
+    return "Packages/" + rel.replace(_os.sep, "/")
+
+
+def _run_syntax_tests_via_api(path):
+    # sublime_api.run_syntax_test returns (total_assertions, [error_msgs]).
+    # Each error_msg is a multi-line string:
+    #   Packages/User/foo/syntax_test_mix.py:4:3
+    #   error: scope does not match
+    #   4 | y = 2
+    #   5 | # ^ keyword.control.flow
+    #     |   ^ this location did not match
+    #   actual:
+    #     |   ^ source.python keyword.operator.assignment.python
+    # For files newly created on disk, ST's resource index may be a few
+    # hundred ms behind the filesystem — the API then returns a single
+    # "unable to read file" message even though the file exists. Poll
+    # sublime.find_resources until the resource is visible, then retry.
+    resource = _to_resource_path(path)
+    if resource is None:
+        return None
+    total, messages = _sublime_api.run_syntax_test(resource)
+    if _is_unable_to_read(messages):
+        _wait_for_resource(resource)
+        total, messages = _sublime_api.run_syntax_test(resource)
+    if _is_unable_to_read(messages):
+        # Under Packages but still not indexed: don't silently fall back to
+        # the 30 s build-panel path — surface the miss to the caller.
+        return {
+            "ok": False,
+            "summary": "<resource not indexed by Sublime Text>",
+            "output": "\n".join(messages),
+            "failures": [],
+        }
+    failures = list(messages)
+    if failures:
+        summary = "FAILED: %d of %d assertions failed" % (len(failures), total)
+    else:
+        summary = "%d assertions passed" % total
+    return {
+        "ok": not failures,
+        "summary": summary,
+        "output": "\n".join(failures) if failures else summary,
+        "failures": failures,
+    }
+
+
+def _is_unable_to_read(messages):
+    return any("unable to read file" in m for m in messages)
+
+
+def _wait_for_resource(resource_path, timeout=1.0):
+    # ST's resource index can lag behind the filesystem by a few hundred
+    # ms on newly-created files; poll find_resources until the resource
+    # becomes visible.
+    basename = resource_path.rsplit("/", 1)[-1]
+    deadline = _time.time() + timeout
+    while _time.time() < deadline:
+        if resource_path in sublime.find_resources(basename):
+            return True
+        _time.sleep(0.02)
+    return False
+
+
+def _run_syntax_tests_via_build(path, timeout):
+    # Fallback: trigger the "Syntax Tests" build variant and scrape the
+    # output panel. Used when sublime_api is unavailable or the path
+    # isn't under Packages/. Addresses the original silent-empty-result
+    # bug: require a non-empty read before considering the poll settled,
+    # and return a self-describing empty case instead of "".
     window = sublime.active_window()
-    view = open_view(path)
+    open_view(path)
     window.run_command("build", {"variant": "Syntax Tests"})
-    panel = window.find_output_panel("exec") or window.get_output_panel("exec")
-    deadline = _time.time() + poll_timeout
+    panel = None
+    for name in ("exec", "syntax_test"):
+        panel = window.find_output_panel(name)
+        if panel is not None:
+            break
+    if panel is None:
+        for name in window.panels():
+            short = name.split(".", 1)[1] if "." in name else name
+            if "exec" in short or "syntax_test" in short:
+                panel = window.find_output_panel(short)
+                if panel is not None:
+                    break
+    if panel is None:
+        return {
+            "ok": False,
+            "summary": "<no build panel found>",
+            "output": "",
+            "failures": [],
+        }
+    deadline = _time.time() + timeout
+    saw_content = False
     last = ""
     while _time.time() < deadline:
         text = panel.substr(sublime.Region(0, panel.size()))
-        if text and text == last and (
-            "assertions passed" in text
-            or "FAILED" in text
-            or "[Finished" in text
-        ):
-            break
+        if text:
+            saw_content = True
+            if text == last and (
+                "assertions passed" in text
+                or "FAILED" in text
+                or "[Finished" in text
+            ):
+                break
         last = text
         _time.sleep(0.1)
     text = panel.substr(sublime.Region(0, panel.size()))
+    if not saw_content:
+        return {
+            "ok": False,
+            "summary": "<no build-panel output captured>",
+            "output": "",
+            "failures": [],
+        }
     summary_line = ""
     for line in reversed(text.splitlines()):
         stripped = line.strip()
         if "assertions" in stripped or "FAILED" in stripped:
             summary_line = stripped
             break
-    ok = "assertions passed" in text and "FAILED" not in text
-    return {"ok": ok, "summary": summary_line, "output": text}
+    # Loose match: any line starting with FAILED. A test file asserting
+    # FAILED-something in its own content could produce false positives;
+    # accepted tradeoff vs returning no failures at all if the format has
+    # drifted.
+    failures = [
+        line for line in text.splitlines()
+        if line.lstrip().startswith("FAILED")
+    ]
+    ok = "assertions passed" in text and not failures
+    return {"ok": ok, "summary": summary_line, "output": text, "failures": failures}
+
+
+def run_syntax_tests(path, timeout=30.0):
+    # Primary path: sublime_api.run_syntax_test(resource_path). It returns
+    # (total_assertions, [error_messages]) synchronously, bypassing the
+    # build-panel race that the original implementation hit. Requires the
+    # file to live under sublime.packages_path().
+    # Fallback: build-panel scrape for paths outside Packages/ or if the
+    # private API disappears.
+    if _sublime_api is not None and hasattr(_sublime_api, "run_syntax_test"):
+        result = _run_syntax_tests_via_api(path)
+        if result is not None:
+            return result
+    return _run_syntax_tests_via_build(path, timeout)
 '''
 
 
-def _exec_on_worker(code):
-    """Run `code` on ST's async worker thread and collect output.
+# Compile HELPERS_SOURCE once at module load and reuse the code object per
+# call. SyntaxError in the helpers will fail plugin_loaded loudly (and the
+# MCP server won't bind) rather than reaching the user via per-call tracebacks
+# — earlier loud failure is the right trade-off during development.
+_HELPERS_CODE = compile(HELPERS_SOURCE, "<sublime-mcp-helpers>", "exec")
 
-    Returns a dict with keys `ok`, `output`, `result`, `error`.
+
+def _exec_on_worker(code):
+    """Run `code` on a dedicated daemon thread and collect output.
+
+    Returns a dict with keys `output`, `result`, `error`. `error is None`
+    means the snippet ran to completion.
     """
     done = threading.Event()
-    result = {"ok": False, "output": "", "result": None, "error": None}
+    result = {"output": "", "result": None, "error": None}
 
     def run():
         buf_out = io.StringIO()
+        # Override `print` in the snippet's namespace rather than
+        # redirecting sys.stdout/sys.stderr globally. The global redirect
+        # isn't thread-safe: under concurrent HTTP handlers, stderr from
+        # an unrelated request's error handler would bleed into this
+        # snippet's captured output.
+        def _print(*args, **kwargs):
+            kwargs.setdefault("file", buf_out)
+            _builtins.print(*args, **kwargs)
         namespace = {
             "__name__": "sublime_mcp_exec",
             "__builtins__": __builtins__,
             "sublime": sublime,
             "sublime_plugin": sublime_plugin,
+            "print": _print,
         }
         try:
-            exec(compile(HELPERS_SOURCE, "<sublime-mcp-helpers>", "exec"), namespace)
+            exec(_HELPERS_CODE, namespace)
         except Exception:
             result["error"] = "helper init failed:\n" + traceback.format_exc()
             done.set()
             return
         try:
-            with contextlib.redirect_stdout(buf_out), contextlib.redirect_stderr(buf_out):
-                exec(compile(code, "<sublime-mcp-snippet>", "exec"), namespace)
-            result["ok"] = True
+            exec(compile(code, "<sublime-mcp-snippet>", "exec"), namespace)
             if "_" in namespace and namespace["_"] is not None:
                 try:
                     result["result"] = repr(namespace["_"])
@@ -229,15 +596,19 @@ def _exec_on_worker(code):
             result["output"] = buf_out.getvalue()
             done.set()
 
-    # Dispatch on ST's async worker thread, not the main UI thread. Snippets
-    # typically wait on ST state (file loads, build panels), and waiting on
-    # the main thread would deadlock — ST's event loop couldn't progress.
-    # Most of the ST API is thread-safe; the async thread is the documented
-    # home for long-running plugin work.
-    sublime.set_timeout_async(run, 0)
+    # Dispatch on a dedicated daemon thread rather than
+    # sublime.set_timeout_async. The async worker's scheduling is coupled
+    # to ST's main event loop — when the caller (notably a sync
+    # DeferrableTestCase under UnitTesting) holds the main thread, the
+    # async callback never runs and every request returns "exec timed out
+    # after 60s". Most of the ST API is thread-safe from any thread, so a
+    # plain threading.Thread works; snippets that need the main UI thread
+    # can still use sublime.set_timeout(lambda: ..., 0) inside the snippet
+    # and poll. `daemon=True` so a runaway snippet doesn't block unload.
+    worker = threading.Thread(target=run, name="sublime-mcp-exec", daemon=True)
+    worker.start()
     if not done.wait(EXEC_TIMEOUT_SECONDS):
         return {
-            "ok": False,
             "output": "",
             "result": None,
             "error": "exec timed out after %ss" % EXEC_TIMEOUT_SECONDS,
@@ -312,7 +683,7 @@ def _dispatch(message):
             "id": req_id,
             "result": {
                 "content": [{"type": "text", "text": text}],
-                "isError": not outcome["ok"],
+                "isError": outcome["error"] is not None,
             },
         }
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,418 @@
+"""Tests for the helper surface exposed inside `exec_sublime_python`.
+
+Each test fires a `tools/call` against the live MCP endpoint and asserts
+on the outcome. Running through MCP (rather than importing helpers
+directly) exercises the JSON-RPC transport and the outer response-shape
+contract in addition to the helper logic itself.
+
+The MCP round-trip is done on a background thread and the test method
+is a generator that yields while the request is in flight. Without
+this, sync `urlopen` holds ST's main thread; ST APIs used inside the
+snippet (`window.open_file`, the filesystem watcher behind
+`sublime.find_resources`) never progress, and every MCP call returns
+`"exec timed out after 60s"`.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+
+import sublime
+from unittesting import DeferrableTestCase
+
+
+MCP_URL = "http://127.0.0.1:47823/mcp"
+SERVER_STARTUP_POLL_ATTEMPTS = 30
+SERVER_STARTUP_POLL_INTERVAL_S = 0.1
+CALL_YIELD_INTERVAL_MS = 50
+
+HEADER = '# SYNTAX TEST "Packages/Python/Python.sublime-syntax"\n'
+
+
+def _post(payload, timeout=65):
+    # Default matches EXEC_TIMEOUT_SECONDS (60) in the plugin with a 5 s
+    # network margin. Used for `initialize` in the startup poll; test
+    # methods go through `_call_tool_yielding` instead so the main
+    # thread is released while ST processes events.
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        MCP_URL, data=data, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _call_tool(code, request_id=1, timeout=65):
+    return _post({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": "exec_sublime_python",
+            "arguments": {"code": code},
+        },
+    }, timeout=timeout)
+
+
+def _call_tool_yielding(code, request_id=1, timeout=65):
+    """Generator: spawns the MCP call on a daemon thread and yields
+    `CALL_YIELD_INTERVAL_MS` until it returns. DeferrableTestCase pauses
+    the generator during each yield, letting ST's main thread run the
+    snippet's ST API calls to completion.
+    """
+    holder = {}
+    def worker():
+        try:
+            holder["resp"] = _call_tool(code, request_id=request_id, timeout=timeout)
+        except BaseException as exc:
+            holder["exc"] = exc
+    t = threading.Thread(target=worker, daemon=True)
+    t.start()
+    deadline = time.time() + timeout + 5
+    while t.is_alive() and time.time() < deadline:
+        yield CALL_YIELD_INTERVAL_MS
+    if "exc" in holder:
+        raise holder["exc"]
+    if "resp" not in holder:
+        raise TimeoutError("MCP call did not complete in %ss" % (timeout + 5))
+    return holder["resp"]
+
+
+def _outcome(resp):
+    return json.loads(resp["result"]["content"][0]["text"])
+
+
+def _wait_for_server():
+    # Synchronous poll so setUpClass works — can't yield from there.
+    last_exc = None
+    for _ in range(SERVER_STARTUP_POLL_ATTEMPTS):
+        try:
+            _post({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "helpers-test", "version": "0"},
+                },
+            }, timeout=2)
+            return
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_exc = exc
+            time.sleep(SERVER_STARTUP_POLL_INTERVAL_S)
+    raise AssertionError("MCP server not reachable: %r" % (last_exc,))
+
+
+def _probe_api_path_available():
+    # Tests run inside ST's plugin host, so we can import sublime_api
+    # directly instead of going through MCP. Avoids the cost of a round-
+    # trip — and avoids the chicken-and-egg where the probe itself would
+    # need `yield` support that setUpClass can't provide.
+    try:
+        import sublime_api
+        return hasattr(sublime_api, "run_syntax_test")
+    except ImportError:
+        return False
+
+
+class HelperTestBase(DeferrableTestCase):
+    FIXTURE_SUBDIR = "sublime_mcp_test_fixtures"
+    api_path_available = False
+
+    @classmethod
+    def setUpClass(cls):
+        _wait_for_server()
+        cls.api_path_available = _probe_api_path_available()
+        if not cls.api_path_available:
+            print(
+                "[sublime-mcp tests] sublime_api.run_syntax_test missing — "
+                "API-path tests skipped"
+            )
+        cls.fixture_dir = os.path.join(
+            sublime.packages_path(), "User", cls.FIXTURE_SUBDIR
+        )
+        if os.path.isdir(cls.fixture_dir):
+            shutil.rmtree(cls.fixture_dir)
+        os.makedirs(cls.fixture_dir)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Close any views that still reference fixture_dir before deleting
+        # the dir itself. Tests avoid sharing fixture paths via
+        # `_testMethodName` prefixing, so setUp makes zero MCP calls; the
+        # trade-off is that ST accumulates dangling views unless we clean
+        # up here. tearDownClass runs on ST's main thread in the plugin
+        # host, so we can call the ST API directly — no MCP round-trip,
+        # which would deadlock the same way setUp used to.
+        try:
+            for w in sublime.windows():
+                for v in list(w.views()):
+                    fn = v.file_name() or ""
+                    if fn.startswith(cls.fixture_dir):
+                        v.set_scratch(True)
+                        v.close()
+        except Exception as exc:
+            print("[sublime-mcp tests] view cleanup failed: %r" % (exc,))
+        if os.path.isdir(cls.fixture_dir):
+            shutil.rmtree(cls.fixture_dir)
+
+    def _write_fixture(self, name, content):
+        # Prefix by test method name so no two tests in the same class
+        # share a fixture path — setUp stays synchronous (no MCP calls)
+        # and tests are isolated from each other's view state.
+        path = os.path.join(self.fixture_dir, "%s__%s" % (self._testMethodName, name))
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+
+class TestResponseShape(HelperTestBase):
+    """Outer MCP response contract: no outer `ok` field; `error is null`
+    on success; `isError` tracks the presence of `error`. Distinct from
+    the inner `ok` some helpers return (e.g. `run_syntax_tests(...)["ok"]`)."""
+
+    def test_success_has_no_outer_ok(self):
+        resp = yield from _call_tool_yielding("print('hi')")
+        outcome = _outcome(resp)
+        self.assertNotIn("ok", outcome)
+        self.assertIsNone(outcome["error"])
+        self.assertEqual(outcome["output"], "hi\n")
+        self.assertFalse(resp["result"]["isError"])
+
+    def test_snippet_exception_sets_error_and_isError(self):
+        resp = yield from _call_tool_yielding("raise RuntimeError('boom')")
+        outcome = _outcome(resp)
+        self.assertNotIn("ok", outcome)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("RuntimeError: boom", outcome["error"])
+        self.assertTrue(resp["result"]["isError"])
+
+
+class TestScopeAtExtensionless(HelperTestBase):
+    """The landmine the feedback flagged: `scope_at` on extension-less files
+    silently returns `text.plain`. `scope_at_test` fixes it by parsing the
+    header."""
+
+    def setUp(self):
+        self.fixture_path = self._write_fixture(
+            "syntax_test_probe", HEADER + "x = 1\n"
+        )
+
+    def test_scope_at_returns_text_plain_on_extensionless(self):
+        resp = yield from _call_tool_yielding(
+            "print(scope_at(%r, 1, 0))" % self.fixture_path
+        )
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "text.plain")
+
+    def test_scope_at_test_parses_header_and_returns_real_scope(self):
+        resp = yield from _call_tool_yielding(
+            "print(scope_at_test(%r, 1, 0))" % self.fixture_path
+        )
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertIn("source.python", outcome["output"])
+
+
+class TestScopeAtTestNoHeader(HelperTestBase):
+    """`scope_at_test` must fail loudly when the header is missing, not
+    silently fall through to Plain Text."""
+
+    def setUp(self):
+        self.fixture_path = self._write_fixture(
+            "plain_no_header.py", "x = 1\n"
+        )
+
+    def test_no_header_raises_value_error(self):
+        resp = yield from _call_tool_yielding(
+            "scope_at_test(%r, 0, 0)" % self.fixture_path
+        )
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("no SYNTAX TEST header", outcome["error"])
+
+
+class TestResolvePosition(HelperTestBase):
+    """`resolve_position` surfaces `text_point`'s past-EOL overflow and
+    past-EOF clamping as distinct, mutually-exclusive fields."""
+
+    def setUp(self):
+        # Row 0 is the header. Row 1 = "x = 1" (5 chars). Row 2 = "y = 2".
+        self.fixture_path = self._write_fixture(
+            "syntax_test_resolve", HEADER + "x = 1\ny = 2\n"
+        )
+
+    def _resolve(self, row, col):
+        # Generator: callers must `yield from self._resolve(...)`.
+        code = (
+            "import json\n"
+            "_ = resolve_position(%r, %d, %d, "
+            "syntax_path='Packages/Python/Python.sublime-syntax')\n"
+            "print(json.dumps(_))\n"
+            % (self.fixture_path, row, col)
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        return json.loads(outcome["output"])
+
+    def test_in_bounds_no_flags_set(self):
+        r = yield from self._resolve(1, 2)
+        self.assertFalse(r["overflow"])
+        self.assertFalse(r["clamped"])
+        self.assertEqual(r["actual"], [1, 2])
+        self.assertEqual(r["requested"], [1, 2])
+
+    def test_past_eol_overflows_into_next_row(self):
+        # Row 1 is 5 chars + \n; col 10 lands in a later row.
+        r = yield from self._resolve(1, 10)
+        self.assertTrue(r["overflow"])
+        self.assertFalse(r["clamped"])
+        self.assertGreater(r["actual"][0], 1)
+
+    def test_past_eof_clamps_to_view_size(self):
+        r = yield from self._resolve(99999, 99999)
+        self.assertTrue(r["clamped"])
+        self.assertFalse(r["overflow"])
+        # View size in chars — point must be exactly view.size().
+        size_resp = yield from _call_tool_yielding(
+            "v = open_view(%r)\nprint(v.size())" % self.fixture_path
+        )
+        size = int(_outcome(size_resp)["output"].strip())
+        self.assertEqual(r["point"], size)
+
+
+class TestRunSyntaxTestsApiPath(HelperTestBase):
+    """Primary path via `sublime_api.run_syntax_test` — synchronous,
+    structured, no panel scraping."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.api_path_available:
+            raise unittest.SkipTest(
+                "sublime_api.run_syntax_test unavailable on this platform"
+            )
+
+    def test_all_assertions_pass(self):
+        path = self._write_fixture(
+            "syntax_test_pass",
+            HEADER + "x = 1\n# ^ source.python\n",
+        )
+        r = yield from self._run(path)
+        self.assertTrue(r["ok"], r)
+        self.assertEqual(r["failures"], [])
+        self.assertIn("assertions passed", r["summary"])
+
+    def test_mixed_pass_fail_returns_structured_failures(self):
+        # One passing assertion, one failing.
+        path = self._write_fixture(
+            "syntax_test_mix",
+            HEADER
+            + "x = 1\n# ^ source.python\n"
+            + "y = 2\n# ^ keyword.control.flow\n",
+        )
+        r = yield from self._run(path)
+        self.assertFalse(r["ok"], r)
+        self.assertEqual(len(r["failures"]), 1, r)
+        msg = r["failures"][0]
+        self.assertIn("syntax_test_mix", msg)
+        self.assertIn("scope does not match", msg)
+
+    def test_consistent_across_repeated_runs(self):
+        # Verifies determinism across repeated calls on the primary path.
+        path = self._write_fixture(
+            "syntax_test_repeat",
+            HEADER
+            + "x = 1\n# ^ keyword.control.flow\n",
+        )
+        first = yield from self._run(path)
+        self.assertFalse(first["ok"], first)
+        self.assertEqual(len(first["failures"]), 1, first)
+        for _ in range(4):
+            r = yield from self._run(path)
+            self.assertEqual(r["ok"], first["ok"])
+            self.assertEqual(len(r["failures"]), len(first["failures"]))
+
+    def _run(self, path):
+        # Generator: callers must `yield from self._run(...)`.
+        code = (
+            "import json\n"
+            "_ = run_syntax_tests(%r)\n"
+            "print(json.dumps(_))\n" % path
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        return json.loads(outcome["output"])
+
+
+class TestRunSyntaxTestsFallback(HelperTestBase):
+    """Fallback path kicks in for files outside `sublime.packages_path()`.
+    The critical contract: never return a silent empty result."""
+
+    def test_outside_packages_self_describes_empty(self):
+        fd, path = tempfile.mkstemp(suffix=".txt")
+        os.close(fd)
+        try:
+            with open(path, "w") as f:
+                f.write("just text\n")
+            code = (
+                "import json\n"
+                "_ = run_syntax_tests(%r, timeout=3.0)\n"
+                "print(json.dumps(_))\n" % path
+            )
+            resp = yield from _call_tool_yielding(code)
+            outcome = _outcome(resp)
+            self.assertIsNone(outcome["error"], outcome.get("error"))
+            r = json.loads(outcome["output"])
+            self.assertFalse(r["ok"])
+            self.assertEqual(r["failures"], [])
+            # Self-describing marker rather than "".
+            self.assertTrue(
+                r["summary"].startswith("<") and r["summary"].endswith(">"),
+                "expected self-describing marker, got %r" % r["summary"],
+            )
+        finally:
+            os.unlink(path)
+
+
+class TestToResourcePath(HelperTestBase):
+    """`_to_resource_path` maps abs paths under Packages/ to resource form
+    and rejects paths outside."""
+
+    def test_abs_path_under_packages(self):
+        abs_path = os.path.join(
+            sublime.packages_path(), "User", "foo", "bar.py"
+        )
+        code = "print(_to_resource_path(%r))" % abs_path
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(
+            outcome["output"].strip(), "Packages/User/foo/bar.py"
+        )
+
+    def test_already_resource_form_returned_as_is(self):
+        code = "print(_to_resource_path('Packages/User/foo/bar.py'))"
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(
+            outcome["output"].strip(), "Packages/User/foo/bar.py"
+        )
+
+    def test_outside_packages_returns_none(self):
+        code = "print(_to_resource_path('/tmp/not-a-package/foo.py'))"
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "None")


### PR DESCRIPTION
Acts on feedback from an AI agent that hit several rough edges using `exec_sublime_python` during a [syntect](https://github.com/trishume/syntect) investigation. Polish pass on the helper surface plus a real test suite — architecture was validated, coverage and clarity were what was missing.

See [`TOOL_DESCRIPTION`](../blob/harden-sublime-helpers/sublime_mcp.py#L35) for the updated surface (new helpers, `text_point` overflow section, syntect-vs-ST recipe) and [`tests/test_helpers.py`](../blob/harden-sublime-helpers/tests/test_helpers.py) for coverage.

One notable behavior change: the outer `ok` field is **dropped** from the tool response. It was strictly redundant with `error is None` and collided with inner helper `ok` semantics. `isError` is now derived from `error is not None`.