### PR TITLE
Lead TOOL_DESCRIPTION with purpose, not mechanism

### DIFF
--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -33,10 +33,10 @@ SERVER_VERSION = "0.1.0"
 
 
 TOOL_DESCRIPTION = """\
-Run Python inside Sublime Text's plugin host (Python 3.8) and get its
-output back. Use this to answer "what does ST actually do" questions:
-scope at a cursor, whether a syntax test passes, what resources ST
-knows about, etc.
+Query Sublime Text for ground-truth answers about scopes, syntax
+resolution, or syntax-test outcomes. Backed by ST's Python plugin
+host (3.8) — run arbitrary Python against a live ST instance and
+capture its output.
 
 ## What's in scope
 


### PR DESCRIPTION
Stacked on #12. Swaps the opening of [`TOOL_DESCRIPTION`](../blob/tool-description-purpose-first/sublime_mcp.py#L35-L39) from mechanism ("Run Python inside Sublime Text's plugin host…") to purpose ("Query Sublime Text for ground-truth answers…") — agents triaging ToolSearch hits read the first sentence first. Compare with `rust-debug`'s purpose-first opening.

## Test plan

Doc-only; not covered by CI. Reload the ST plugin post-merge and confirm the live `tools/list` description leads with the new sentence.