### PR TITLE
Recognise deferred tools in sublime-mcp preflight

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -20,7 +20,7 @@ This skill drives the `sublime-mcp` server to get authoritative answers from Sub
 
 ## 1. Preflight — check before driving the tool
 
-If `mcp__sublime-text__exec_sublime_python` is in your toolbox, skip to §2.
+If `mcp__sublime-text__exec_sublime_python` appears anywhere in your tool surface — either listed in the deferred-tools system-reminder or already resolved in your toolbox — skip to §2.
 
 If it's missing, diagnose with:
 


### PR DESCRIPTION
The §1 preflight in `skills/sublime-mcp/SKILL.md` keyed off "in your toolbox", which misses harnesses that defer MCP tools — those list the tool by name in a system-reminder until `ToolSearch` resolves the schema, so the old wording sent agents through the diagnostic despite a healthy server. Accept either surface as evidence the server is registered.