### PR TITLE
Headless-ST safety net + non-# testtoken regression coverage

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -29,9 +29,12 @@ claude mcp list | grep sublime-text
 curl -s -X POST http://127.0.0.1:47823/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+curl -s -X POST http://127.0.0.1:47823/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"print(len(sublime.windows()))"}}}'
 ```
 
-Expected: `claude mcp list` shows `sublime-text ✓ Connected`; the curl call returns a JSON-RPC `result` with a `protocolVersion`. If either fails, point the user at `install.md` in this skill's directory. Do not attempt to fall back to manual ST UI inspection without first telling the user the skill cannot run.
+Expected: `claude mcp list` shows `sublime-text ✓ Connected`; the second call returns a JSON-RPC `result` with a `protocolVersion`; the third call's `output` is `"1\n"` or higher. If `claude mcp list` or the second call fails, point the user at `install.md` in this skill's directory. If the third call's `output` is `"0\n"`, ST's plugin host is running but headless — ask the user to open an ST window (`open -a "Sublime Text"` on macOS) before proceeding; helpers that drive views (`open_view`, `scope_at`, `scope_at_test`, `resolve_position`) raise `RuntimeError` in this state. Do not attempt to fall back to manual ST UI inspection without first telling the user the skill cannot run.
 
 ## 2. Decide whether this skill is the right call
 
@@ -74,6 +77,12 @@ print(scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8))
 print(scope_at_test("/path/to/syntax_test_git_config", 71, 28))
 ```
 
+The header parser is comment-token-agnostic — it accepts `#`, `//`, `<!--`, `;`, `--`, `|`, etc. Markdown's pipe-comment header works the same way:
+
+```python
+print(scope_at_test("/path/to/syntax_test_markdown.md", 12, 4))
+```
+
 ### Run syntax tests against a file
 
 ```python
@@ -92,6 +101,8 @@ Branch on `summary`, not on `isError` — `summary` disambiguates states that `i
 | `"<resource not indexed by Sublime Text>"` | file lives under `Packages/` but ST hasn't indexed it — check the symlink |
 | `"<no build panel found>"`                 | ST's build system produced no output panel — session-state oddity |
 | `"<no build-panel output captured>"`       | build variant ran but produced no output — rare timing issue    |
+
+If `summary` is `<no build panel found>`, fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — this state is a known gap tracked as #4/#5.
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 
@@ -158,7 +169,7 @@ Measured per-call latency is tracked in #10.
 
 ## 6. Known limitations / tracking
 
-_Last synced with issue state: 2026-04-24._
+_Last synced with issue state: 2026-04-25._
 
 - **#4** — strict `FAILED:` regex in the build-panel fallback (currently a loose line-prefix match).
 - **#5** — populated-output test for the fallback path (blocked by #4).

--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -32,18 +32,39 @@ Re-run the symlink from [`README.md#install`](../../README.md#install) and reope
 ST's plugin host can run while no editor window is open (the app stays alive in the background, especially on macOS). Helpers that drive views (`open_view`, `scope_at`, `scope_at_test`, `resolve_position`) raise `RuntimeError: open_view: Sublime Text has no open window` in this state. Open one:
 
 ```bash
-open -a "Sublime Text"   # macOS
-subl                     # Linux/Windows, if the CLI helper is on PATH
+# macOS
+open -a "Sublime Text"
+
+# Linux: launch from your desktop entry, or invoke the binary directly
+# (often `sublime_text` or `subl` if you've set up a symlink on PATH).
+# Windows: launch via the Start menu / taskbar shortcut. There is no
+# universal CLI helper.
 ```
 
-To reproduce headlessness deliberately (e.g. for testing the guard end-to-end):
+To reproduce headlessness deliberately and verify the guard end-to-end (macOS recipe — Linux/Windows have no equivalent for AppleScript-driven window control, so verify there by quitting all windows manually instead):
 
 ```bash
-# Save or discard any unsaved work first — the call below is a polite
-# quit on each window and will block on the unsaved-buffer dialog. Do
-# NOT pass `saving no` (destructive, risks data loss).
+# Step 1. Save or discard any unsaved work — the close call below is a
+# polite per-window quit and will block on the unsaved-buffer dialog.
+# Do NOT pass `saving no` (destructive, risks data loss).
 osascript -e 'tell app "Sublime Text" to close every window'
 osascript -e 'tell app "Sublime Text" to count of windows'   # → 0
+
+# Step 2. Confirm the plugin host still sees zero windows.
+curl -s -X POST http://127.0.0.1:47823/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"print(len(sublime.windows()))"}}}'
+# Expected: response `output` contains "0\n".
+
+# Step 3. Trigger the guard. Any path works — the guard fires before
+# the file is read.
+curl -s -X POST http://127.0.0.1:47823/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"open_view(\"/tmp/anything\")"}}}'
+# Expected: response `error` contains "no open window" and "install.md".
+
+# Step 4. Recover by opening any window, then retry the original call.
+open -a "Sublime Text"
 ```
 
 ## If Claude Code can't see the server

--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -27,6 +27,25 @@ Returns ST's build number in `output` on a healthy setup. Connection refused →
 
 Re-run the symlink from [`README.md#install`](../../README.md#install) and reopen ST (or save any `.py` file under `Packages/User/`) to trigger `plugin_loaded()`. The ST console should show the listening line.
 
+## If Sublime Text has no open window
+
+ST's plugin host can run while no editor window is open (the app stays alive in the background, especially on macOS). Helpers that drive views (`open_view`, `scope_at`, `scope_at_test`, `resolve_position`) raise `RuntimeError: open_view: Sublime Text has no open window` in this state. Open one:
+
+```bash
+open -a "Sublime Text"   # macOS
+subl                     # Linux/Windows, if the CLI helper is on PATH
+```
+
+To reproduce headlessness deliberately (e.g. for testing the guard end-to-end):
+
+```bash
+# Save or discard any unsaved work first — the call below is a polite
+# quit on each window and will block on the unsaved-buffer dialog. Do
+# NOT pass `saving no` (destructive, risks data loss).
+osascript -e 'tell app "Sublime Text" to close every window'
+osascript -e 'tell app "Sublime Text" to count of windows'   # → 0
+```
+
 ## If Claude Code can't see the server
 
 ```bash

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -270,9 +270,9 @@ def open_view(path, timeout=5.0):
     if window is None or len(sublime.windows()) == 0:
         raise RuntimeError(
             "open_view: Sublime Text has no open window. The plugin host is "
-            "running but headless. Launch ST with a window — e.g. "
-            "`open -a 'Sublime Text'` on macOS, `subl` on Linux/Windows — "
-            "then retry. See skills/sublime-mcp/install.md for details."
+            "running but headless. Launch ST with a window (e.g. "
+            "`open -a 'Sublime Text'` on macOS) and retry. See "
+            "skills/sublime-mcp/install.md for platform-specific options."
         )
     view = window.open_file(path)
     deadline = _time.time() + timeout

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -267,6 +267,13 @@ _SYNTAX_TEST_HEADER = _re.compile(r'SYNTAX TEST\s+"([^"]+)"')
 
 def open_view(path, timeout=5.0):
     window = sublime.active_window()
+    if window is None or len(sublime.windows()) == 0:
+        raise RuntimeError(
+            "open_view: Sublime Text has no open window. The plugin host is "
+            "running but headless. Launch ST with a window — e.g. "
+            "`open -a 'Sublime Text'` on macOS, `subl` on Linux/Windows — "
+            "then retry. See skills/sublime-mcp/install.md for details."
+        )
     view = window.open_file(path)
     deadline = _time.time() + timeout
     while view.is_loading() and _time.time() < deadline:
@@ -295,6 +302,10 @@ def scope_at(path, row, col):
 
 
 def assign_syntax_and_wait(view, resource_path, timeout=2.0):
+    # Invariant: `view` came from `open_view`, which refuses to return
+    # views from a headless ST (no window) — so `view.size() > 0` need
+    # not be re-asserted here. A direct caller bypassing `open_view` on
+    # a zero-size view will time out on stage 1 below.
     # ST exposes no public tokenisation-complete signal. Stage 1 waits for
     # view.settings()["syntax"] to reflect the requested path (usually one
     # tick, but guards against a typo landing silently). Stage 2 is a

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -33,6 +33,8 @@ SERVER_STARTUP_POLL_INTERVAL_S = 0.1
 CALL_YIELD_INTERVAL_MS = 50
 
 HEADER = '# SYNTAX TEST "Packages/Python/Python.sublime-syntax"\n'
+HEADER_PIPE_MD = '| SYNTAX TEST "Packages/Markdown/Markdown.sublime-syntax"\n'
+HEADER_HTML_COMMENT = '<!-- SYNTAX TEST "Packages/HTML/HTML.sublime-syntax" -->\n'
 
 
 def _post(payload, timeout=65):
@@ -416,3 +418,110 @@ class TestToResourcePath(HelperTestBase):
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
         self.assertEqual(outcome["output"].strip(), "None")
+
+
+class TestScopeAtTestPipeHeader(HelperTestBase):
+    """`scope_at_test` must accept markdown's `|` comment-token header.
+    The fixture is extensionless so ST can't infer the syntax — a parser
+    failure on `|` would surface as a `text.plain` scope, not Markdown.
+    """
+
+    def setUp(self):
+        self.fixture_path = self._write_fixture(
+            "syntax_test_pipe_md", HEADER_PIPE_MD + "# heading\n"
+        )
+
+    def test_pipe_comment_header_parses(self):
+        resp = yield from _call_tool_yielding(
+            "print(scope_at_test(%r, 1, 0))" % self.fixture_path
+        )
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertIn("text.html.markdown", outcome["output"])
+
+
+class TestScopeAtTestHtmlComment(HelperTestBase):
+    """`scope_at_test` must accept HTML's `<!--` comment-token header.
+    Extensionless fixture for the same reason as the pipe-header test —
+    without that, ST would infer the syntax from the extension and a
+    broken header parser would not surface.
+    """
+
+    def setUp(self):
+        self.fixture_path = self._write_fixture(
+            "syntax_test_html_comment", HEADER_HTML_COMMENT + "<p>x</p>\n"
+        )
+
+    def test_html_comment_header_parses(self):
+        resp = yield from _call_tool_yielding(
+            "print(scope_at_test(%r, 1, 0))" % self.fixture_path
+        )
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertIn("text.html", outcome["output"])
+
+
+class TestHeadlessGuard(HelperTestBase):
+    """`open_view` raises `RuntimeError` when ST has no open window.
+
+    Both clauses of the guard (`active_window() is None` AND
+    `len(sublime.windows()) == 0`) are exercised in CI by patching
+    `sublime` module attributes via `unittest.mock.patch.object`. Each
+    test patches BOTH names, even though only one clause is under test:
+    the other patch forces the non-tested clause's predicate False so a
+    regression in the tested clause cannot be silently rescued by the
+    other (e.g., a CI environment that happens to have no real window).
+
+    Stability invariant: these tests rely on `open_view` reading
+    `sublime.active_window` / `sublime.windows` *through the module at
+    call time* (sublime_mcp.py:268-269). A future refactor that captures
+    references at module import would silently neuter both tests because
+    the patch would land on names the helper no longer reads.
+
+    Blast-radius caveat: while a `patch.object` context is active, the
+    override is process-global within the ST plugin host and visible to
+    autosave timers, indexers, concurrent MCP daemon-thread requests,
+    and ST's UI thread. Keep the patch window as narrow as possible —
+    wrap *only* the `open_view` call, not surrounding setUp / fixture
+    writes / assertions. A multi-helper patch under one context is a
+    code smell; split into smaller scoped patches instead.
+    """
+
+    GUARD_SNIPPET = (
+        "import unittest.mock\n"
+        "with unittest.mock.patch.object(sublime, 'windows', new={windows_mock}), \\\n"
+        "     unittest.mock.patch.object(sublime, 'active_window', new={aw_mock}):\n"
+        "    open_view('/tmp/sublime_mcp_headless_test')\n"
+    )
+
+    def test_open_view_raises_on_zero_windows(self):
+        # Load-bearing case: non-None active_window, len(windows()) == 0.
+        # `aw_mock=lambda: object()` forces the `is None` clause False so
+        # this test can't pass for the wrong reason in a CI environment
+        # where the harness happens to have no real window.
+        code = self.GUARD_SNIPPET.format(
+            windows_mock="lambda: []",
+            aw_mock="lambda: object()",
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("RuntimeError", outcome["error"])
+        self.assertIn("no open window", outcome["error"])
+        self.assertIn("install.md", outcome["error"])
+
+    def test_open_view_raises_on_none_active_window(self):
+        # Defensive case: active_window() is None. `windows_mock=lambda:
+        # [object()]` forces the `windows() == 0` clause False so a
+        # regression in the `is None` branch cannot be rescued by the
+        # other clause.
+        code = self.GUARD_SNIPPET.format(
+            windows_mock="lambda: [object()]",
+            aw_mock="lambda: None",
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("RuntimeError", outcome["error"])
+        self.assertIn("no open window", outcome["error"])
+        self.assertIn("install.md", outcome["error"])

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -458,7 +458,11 @@ class TestScopeAtTestHtmlComment(HelperTestBase):
         )
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
-        self.assertIn("text.html", outcome["output"])
+        # `text.html.basic` rather than `text.html`: the looser prefix
+        # would also match `text.html.markdown`, so a regression that
+        # mis-applied Markdown syntax to the HTML fixture would slip
+        # through.
+        self.assertIn("text.html.basic", outcome["output"])
 
 
 class TestHeadlessGuard(HelperTestBase):


### PR DESCRIPTION
On a headless ST plugin host (`active_window()` returns a sentinel; `len(sublime.windows()) == 0`) `open_view` produced a zero-size view, which surfaced as a misleading `_parse_syntax_test_header` `ValueError("no SYNTAX TEST header on line 0: ''")` for any caller — most often misdiagnosed as a regex bug for non-`#` testtokens. Guard at `sublime_mcp.py:268-275` raises a self-describing `RuntimeError` instead. `TestHeadlessGuard` covers both clauses hermetically; `TestScopeAtTest{PipeHeader,HtmlComment}` lock the comment-token-agnostic regex contract on extensionless fixtures so a parser regression can't hide behind ST's extension-based syntax inference. `SKILL.md` §1 grows a `len(sublime.windows())` probe; `install.md` gains a matching subsection.

## Test plan

CI covers the guard and header-dialect tests hermetically. CI cannot exercise real headless ST without disturbing its own window state — manual integration repro at `skills/sublime-mcp/install.md` ("If Sublime Text has no open window") is the current ceiling.