### PR TITLE
Reverse-map symlinked Packages entries in _to_resource_path

### DIFF
--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -67,6 +67,40 @@ curl -s -X POST http://127.0.0.1:47823/mcp \
 open -a "Sublime Text"
 ```
 
+## Verifying symlinked-package URI resolution
+
+`_to_resource_path` reverse-maps a path under a symlinked entry of `sublime.packages_path()` (e.g. `testdata/Packages/Markdown` symlinked as `~/Library/.../Packages/Markdown`) to a `Packages/<symlink_name>/...` URI that ST's resource indexer agrees on. To verify end-to-end against your real ST install:
+
+> **Warning:** this recipe creates a symlink in your real ST Packages directory. Step 3 removes it. If you skip cleanup, ST's resource indexer keeps treating the target as a registered package across sessions until you manually `unlink` it. The recipe uses a deliberately unique symlink name (`__sublime_mcp_verify__`) so it cannot collide with any real package or shadow ST's bundled syntax handling.
+
+macOS paths shown — adjust for Linux's `~/.config/sublime-text/Packages/` or your platform's equivalent.
+
+```bash
+# Step 1. Pre-check (recovers from a prior interrupted run; -L matches
+# only symlinks, so it cannot clobber a real package), then create.
+[ -L ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__ ] && \
+  unlink ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
+ln -s /path/to/your/Packages/Markdown \
+      ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
+
+# Step 2. Call run_syntax_tests with the *target path* — the input form
+# that triggered <no build panel found> on pre-fix code. The symlink-
+# walk now reverse-maps it to Packages/__sublime_mcp_verify__/...
+curl -s -X POST http://127.0.0.1:47823/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"r = run_syntax_tests(\"/path/to/your/Packages/Markdown/tests/syntax_test_markdown.md\"); print(r[\"summary\"])"}}}'
+# Success: `summary` is a numeric "N assertions passed" or
+# "FAILED: M of N assertions failed". Explicitly NOT
+# "<no build panel found>" (the API path didn't fire — _to_resource_path
+# returned None) and NOT "<resource not indexed by Sublime Text>" (the
+# API path ran but ST's resource indexer disagreed with the
+# reconstructed URI).
+
+# Step 3. Cleanup (do not skip). unlink, NOT rm -r / rm -rf — those
+# follow the symlink and would delete the target's contents.
+unlink ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
+```
+
 ## If Claude Code can't see the server
 
 ```bash

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -400,9 +400,20 @@ def find_resources(pattern):
 
 def _to_resource_path(path):
     # sublime_api.run_syntax_test only accepts resource paths of the form
-    # "Packages/...". For abs paths under sublime.packages_path(), strip
-    # the prefix and re-prepend "Packages". Returns None if the path
-    # isn't under the Packages tree; caller decides whether to fall back.
+    # "Packages/...". Three cases:
+    # 1. Already in resource form: passthrough.
+    # 2. Filesystem path under sublime.packages_path() directly (or via
+    #    a symlink-name path like ~/.../Packages/Markdown/foo.md):
+    #    strip the prefix. abspath preserves the symlink-name path so
+    #    relpath against packages_root produces a clean result.
+    # 3. Filesystem path under a realpath target reached by a symlink in
+    #    packages_root: walk symlinks, realpath each, reverse-map. ST
+    #    indexes resources by the symlink name, so the URI must use the
+    #    symlink name even when the input is the realpath target. realpath
+    #    both sides so platform symlink chains (e.g. /tmp -> /private/tmp
+    #    on macOS) don't cause a false miss.
+    # Returns None if the path isn't under the Packages tree (directly or
+    # via symlink); caller decides whether to fall back.
     if path.startswith("Packages/") or path.startswith("Packages\\"):
         return path
     packages_root = sublime.packages_path()
@@ -410,10 +421,38 @@ def _to_resource_path(path):
     try:
         rel = _os.path.relpath(abs_path, packages_root)
     except ValueError:
+        rel = None
+    if rel is not None and not rel.startswith("..") and not _os.path.isabs(rel):
+        return "Packages/" + rel.replace(_os.sep, "/")
+    # Don't cache the listing: developers commonly add/remove symlinks in
+    # packages_path() while iterating on a package, and a stale cache
+    # would silently return wrong URIs (or None for a newly-added
+    # symlink). One listdir on a small directory is cheap; correctness
+    # wins.
+    try:
+        entries = _os.listdir(packages_root)
+    except OSError:
         return None
-    if rel.startswith("..") or _os.path.isabs(rel):
-        return None
-    return "Packages/" + rel.replace(_os.sep, "/")
+    abs_path_real = _os.path.realpath(abs_path)
+    for name in entries:
+        entry_path = _os.path.join(packages_root, name)
+        if not _os.path.islink(entry_path):
+            continue
+        try:
+            target_real = _os.path.realpath(entry_path)
+        except OSError:
+            continue
+        if (abs_path_real == target_real
+                or abs_path_real.startswith(target_real + _os.sep)):
+            try:
+                rel_under_target = _os.path.relpath(abs_path_real, target_real)
+            except ValueError:
+                continue
+            if rel_under_target == ".":
+                return "Packages/" + name
+            return ("Packages/" + name + "/"
+                    + rel_under_target.replace(_os.sep, "/"))
+    return None
 
 
 def _run_syntax_tests_via_api(path):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,6 +16,7 @@ snippet (`window.open_file`, the filesystem watcher behind
 import json
 import os
 import shutil
+import sys
 import tempfile
 import threading
 import time
@@ -529,3 +530,96 @@ class TestHeadlessGuard(HelperTestBase):
         self.assertIn("RuntimeError", outcome["error"])
         self.assertIn("no open window", outcome["error"])
         self.assertIn("install.md", outcome["error"])
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "TestToResourcePathSymlinked requires symlink creation, which "
+    "needs SeCreateSymbolicLinkPrivilege or Developer Mode on Windows. "
+    "A junction (mklink /J) workaround has subtle filesystem-semantics "
+    "differences that would weaken the test's invariants.",
+)
+class TestToResourcePathSymlinked(HelperTestBase):
+    """`_to_resource_path` must reverse-map a realpath-target input through
+    a symlink in `sublime.packages_path()`, returning a `Packages/
+    <symlink_name>/...` URI rather than `None`.
+
+    Blast-radius caveat: setUp creates a symlink under a deliberately
+    unique name (`__sublime_mcp_test_symlink__`) inside the user's real
+    `sublime.packages_path()`. While the symlink is in place, ST's
+    resource indexer treats it as a registered package — same kind of
+    host-wide mutation as `TestHeadlessGuard`'s `patch.object`, just via
+    filesystem rather than module-attribute mutation.
+
+    Cleanup discipline: the symlink is registered with `addCleanup`
+    (not `tearDown`) immediately after `os.symlink` so it fires even if
+    setUp partial-fails. A defensive `lexists`-then-`unlink` runs at
+    the *start* of setUp to recover from a prior crashed run that left
+    the symlink behind. The unique name ensures the defensive removal
+    cannot clobber a real user package.
+    """
+
+    SYMLINK_NAME = "__sublime_mcp_test_symlink__"
+
+    def setUp(self):
+        self.symlink_path = os.path.join(
+            sublime.packages_path(), self.SYMLINK_NAME
+        )
+        if os.path.lexists(self.symlink_path):
+            os.unlink(self.symlink_path)
+        self.target_dir = tempfile.mkdtemp(prefix="sublime_mcp_test_target_")
+        self.addCleanup(shutil.rmtree, self.target_dir, ignore_errors=True)
+        with open(os.path.join(self.target_dir, "foo.md"), "w") as f:
+            f.write("# heading\n")
+        os.symlink(self.target_dir, self.symlink_path)
+        self.addCleanup(self._unlink_symlink)
+
+    def _unlink_symlink(self):
+        try:
+            os.unlink(self.symlink_path)
+        except FileNotFoundError:
+            pass
+
+    def test_symlink_path_input_returns_symlink_name_uri(self):
+        # Regression-proofing: passing the path under the symlink name
+        # already worked on pre-fix code (abspath preserves the symlink
+        # path; relpath against packages_root is clean). Locks the
+        # contract that the symlink-walk doesn't break this case.
+        symlink_input = os.path.join(self.symlink_path, "foo.md")
+        code = "print(_to_resource_path(%r))" % symlink_input
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(
+            outcome["output"].strip(),
+            "Packages/%s/foo.md" % self.SYMLINK_NAME,
+        )
+
+    def test_target_path_input_returns_symlink_name_uri(self):
+        # The bug: passing the realpath-target path falls through to None
+        # on pre-fix code (relpath against packages_root yields a `..`-
+        # laden path). After the fix the symlink-walk reverse-maps to
+        # the symlink-name URI ST's resource indexer agrees on.
+        target_input = os.path.join(self.target_dir, "foo.md")
+        code = "print(_to_resource_path(%r))" % target_input
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(
+            outcome["output"].strip(),
+            "Packages/%s/foo.md" % self.SYMLINK_NAME,
+        )
+
+    def test_outside_packages_target_path_returns_none(self):
+        # Negative case: a tempdir not symlinked into packages_root
+        # should not false-positive on the symlink-walk.
+        unrelated = tempfile.mkdtemp(prefix="sublime_mcp_test_unrelated_")
+        self.addCleanup(shutil.rmtree, unrelated, ignore_errors=True)
+        unrelated_input = os.path.join(unrelated, "foo.md")
+        with open(unrelated_input, "w") as f:
+            f.write("x\n")
+        code = "print(_to_resource_path(%r))" % unrelated_input
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "None")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -611,8 +611,12 @@ class TestToResourcePathSymlinked(HelperTestBase):
         )
 
     def test_outside_packages_target_path_returns_none(self):
-        # Negative case: a tempdir not symlinked into packages_root
-        # should not false-positive on the symlink-walk.
+        # Negative case. The class's own symlink (__sublime_mcp_test_
+        # symlink__) is in place during this test, so the assertion is
+        # the stronger "no false-positive against ANY symlink in
+        # packages_root" — not merely "no symlink → None". Locks intent
+        # against a future reader who assumes packages_root is empty
+        # at test time.
         unrelated = tempfile.mkdtemp(prefix="sublime_mcp_test_unrelated_")
         self.addCleanup(shutil.rmtree, unrelated, ignore_errors=True)
         unrelated_input = os.path.join(unrelated, "foo.md")


### PR DESCRIPTION
Closes #9.

When a fixture lives outside `sublime.packages_path()` and is reached via a symlink (e.g. `testdata/Packages/Markdown` symlinked as `~/Library/.../Packages/Markdown`), callers naturally pass the realpath-target path. `os.path.abspath` does not dereference symlinks, so the existing `relpath`-against-`packages_root` check rejected anything outside the literal Packages tree and `_run_syntax_tests_via_api` silently fell through to the build-panel fallback. `_to_resource_path` now walks `os.path.islink` entries of `packages_root`, `realpath`s each, and reverse-maps an input that lives under any resolved target to a `Packages/<symlink_name>/...` URI — preserving the symlink-name URI ST's resource indexer agrees on.

## Test plan

`TestToResourcePathSymlinked` covers the three input forms (symlink-path, target-path, unrelated-target) hermetically in CI. ST's resource-indexer agreement with the reconstructed URI is checked end-to-end manually — verifying it from CI would require holding a `Packages/` symlink in place for the full UnitTesting session (per-test fixtures clean up before ST's async indexer settles, so `<resource not indexed by Sublime Text>` would dominate). Manual recipe at `skills/sublime-mcp/install.md` ("Verifying symlinked-package URI resolution").