### PR TITLE
Point <no build panel found> note at #17/#25, not #4/#5

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -102,7 +102,7 @@ Branch on `summary`, not on `isError` — `summary` disambiguates states that `i
 | `"<no build panel found>"`                 | ST's build system produced no output panel — session-state oddity |
 | `"<no build-panel output captured>"`       | build variant ran but produced no output — rare timing issue    |
 
-If `summary` is `<no build panel found>`, fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — this state is a known gap tracked as #4/#5.
+If `summary` is `<no build panel found>`, fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — this state is a known gap tracked as #17/#25.
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 


### PR DESCRIPTION
The cross-reference at `skills/sublime-mcp/SKILL.md:105` for the
`<no build panel found>` placeholder pointed at #4/#5, which both cover
the *panel-present* scrape path (regex strictness, populated-output test).

The actual axes for this placeholder are #17 (recovery / fallback recipe —
explicitly the "panel never appeared" branch) and #25 (placeholder-vs-
assertion-outcome legibility, which lists this exact line in its touch sites).

## Test plan

- [ ] Docs-only; no CI deltas expected.