### PR TITLE
Replace run_syntax_tests `ok` with `state` discriminator

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -56,7 +56,7 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 
 - Assign to `_` inside the snippet to get its `repr` back as `result`.
 - `error` is populated on uncaught exception; `isError` is derived from `error is not None`.
-- **Inner helper `ok` keys are unrelated to the top-level success signal.** `run_syntax_tests(...)["ok"]` means "did every assertion pass?", not "did the call succeed?".
+- **Helper-level status fields are unrelated to the top-level success signal.** `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed` / `inconclusive`), not whether the MCP call succeeded.
 - Preloaded helpers (`scope_at`, `scope_at_test`, `resolve_position`, `run_syntax_tests`, `open_view`, `assign_syntax_and_wait`, `find_resources`, `reload_syntax`) are in scope without import.
 
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
@@ -92,17 +92,15 @@ for msg in r["failures"]:
     print(msg)
 ```
 
-Branch on `summary`, not on `isError` — `summary` disambiguates states that `isError` collapses:
+Branch on `state`, not on `isError` — `state` disambiguates outcomes that `isError` collapses:
 
-| `summary` value                            | meaning                                                         |
-| ------------------------------------------ | --------------------------------------------------------------- |
-| `"N assertions passed"`                    | all good                                                        |
-| `"FAILED: N of M assertions failed"`       | read `failures` for specifics                                   |
-| `"<resource not indexed by Sublime Text>"` | file lives under `Packages/` but ST hasn't indexed it — check the symlink |
-| `"<no build panel found>"`                 | ST's build system produced no output panel — session-state oddity |
-| `"<no build-panel output captured>"`       | build variant ran but produced no output — rare timing issue    |
+| `state`          | meaning                                                                          | `summary` shape                                  | `failures`     |
+| ---------------- | -------------------------------------------------------------------------------- | ------------------------------------------------ | -------------- |
+| `"passed"`       | runner completed; every assertion matched                                        | assertion-count headline                         | `[]`           |
+| `"failed"`       | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated      |
+| `"inconclusive"` | runner could not complete the run; assertion outcomes are unknown                | descriptive prose naming the cause               | `[]`           |
 
-If `summary` is `<no build panel found>`, fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — this state is a known gap tracked as #17/#25.
+If `state == "inconclusive"`, fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — these answer the underlying ground-truth question without going through ST's build path. Causes that surface as `inconclusive` include the build-panel-missing case (tracked as #17), unindexed resources, and timeouts on a panel that produced no output.
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 
@@ -186,7 +184,7 @@ _Last synced with issue state: 2026-04-26._
 - `scope_at(path, row, col) -> str` — open file, return `view.scope_name` at point. Silently wrong on extension-less files.
 - `scope_at_test(path, row, col) -> str` — parse `# SYNTAX TEST` header, assign that syntax, return scope. Right for extension-less syntax-test files.
 - `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags.
-- `run_syntax_tests(path, timeout=30.0) -> dict` — run ST's built-in syntax-test runner. `{ok, summary, output, failures}`.
+- `run_syntax_tests(path, timeout=30.0) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`.
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.
 - `find_resources(pattern) -> list[str]` — wrap `sublime.find_resources`.

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -65,17 +65,24 @@ The following names are preloaded:
   "text_point overflow" below. Optional `syntax_path` calls
   `assign_syntax_and_wait` on the view first.
 - `run_syntax_tests(path, timeout=30.0) -> dict` — returns
-  `{"ok": bool, "summary": str, "output": str, "failures": list[str]}`.
-  `ok` is True when all assertions passed. `failures` is one entry
-  per failed assertion with ST's own diagnostic (file:row:col,
-  "error: scope does not match", then the expected/actual snippet).
-  Primary path uses `sublime_api.run_syntax_test`, which returns
-  synchronously from a private ST API; falls back to the "Syntax
-  Tests" build variant for paths outside `sublime.packages_path()`.
-  The API path requires the file to live under Packages/ (either as
-  an absolute path rooted there, or the `Packages/...` resource
-  form); syntect-style investigations typically symlink the repo's
-  test dir into Packages/ for this reason.
+  `{"state": str, "summary": str, "output": str, "failures": list[str]}`.
+  `state` is one of `"passed"` (all assertions matched), `"failed"`
+  (the runner completed but some assertions did not match), or
+  `"inconclusive"` (the runner could not complete the run, so
+  assertion outcomes are unknown). `summary` is a human-readable
+  description of the state — an assertion-count headline for
+  `passed`/`failed`, descriptive prose naming the cause for
+  `inconclusive`. `failures` is one entry per failed assertion with
+  ST's own diagnostic (file:row:col, "error: scope does not match",
+  then the expected/actual snippet); populated only when
+  `state == "failed"`. Primary path uses `sublime_api.run_syntax_test`,
+  which returns synchronously from a private ST API; falls back to
+  the "Syntax Tests" build variant for paths outside
+  `sublime.packages_path()`. The API path requires the file to live
+  under Packages/ (either as an absolute path rooted there, or the
+  `Packages/...` resource form); syntect-style investigations
+  typically symlink the repo's test dir into Packages/ for this
+  reason.
 - `reload_syntax(resource_path) -> None` — force-reloads a
   `.sublime-syntax` resource. Useful when ST cached an older version
   (e.g. after an external edit via symlink).
@@ -127,10 +134,10 @@ requests). The response shape is:
 {"output": str, "result": str|null, "error": str|null}
 ```
 
-`error is null` means the snippet ran to completion. Note that some
-helpers return their own dict containing an `ok` key (e.g.
-`run_syntax_tests(...)["ok"]` — "did all assertions pass?"); that
-inner `ok` is unrelated to the absence of `error` at the top level.
+`error is null` means the snippet ran to completion. Helper-level
+status (e.g. `run_syntax_tests(...)["state"]` — passed / failed /
+inconclusive) is unrelated to the absence of `error` at the top
+level.
 
 ## Recipes
 
@@ -189,17 +196,19 @@ print("overflow:", r["overflow"], "clamped:", r["clamped"], "actual:", r["actual
 
 # 3. What does ST's own assertion runner say about this file?
 r = run_syntax_tests("/path/to/Packages/Git Formats/tests/syntax_test_git_config")
-if r["ok"]:
+if r["state"] == "passed":
     print("ST passes all assertions → syntect harness diverges from ST")
-else:
+elif r["state"] == "failed":
     print("ST fails these too → test data itself has the issue:")
     for msg in r["failures"]:
         print(msg)
+else:
+    print("ST runner inconclusive →", r["summary"])
 ```
 
-Note: `run_syntax_tests(...)["ok"]` is the inner "all assertions
-passed" signal; unrelated to the top-level `error is None` success
-check on the MCP response.
+Note: `run_syntax_tests(...)["state"]` is the helper-level
+assertion-run outcome; unrelated to the top-level `error is None`
+success check on the MCP response.
 
 ### Reload a syntax file after an external edit
 
@@ -480,18 +489,22 @@ def _run_syntax_tests_via_api(path):
         # Under Packages but still not indexed: don't silently fall back to
         # the 30 s build-panel path — surface the miss to the caller.
         return {
-            "ok": False,
-            "summary": "<resource not indexed by Sublime Text>",
+            "state": "inconclusive",
+            "summary": (
+                "Sublime Text has not indexed the resource at %s" % resource
+            ),
             "output": "\n".join(messages),
             "failures": [],
         }
     failures = list(messages)
     if failures:
         summary = "FAILED: %d of %d assertions failed" % (len(failures), total)
+        state = "failed"
     else:
         summary = "%d assertions passed" % total
+        state = "passed"
     return {
-        "ok": not failures,
+        "state": state,
         "summary": summary,
         "output": "\n".join(failures) if failures else summary,
         "failures": failures,
@@ -538,8 +551,11 @@ def _run_syntax_tests_via_build(path, timeout):
                     break
     if panel is None:
         return {
-            "ok": False,
-            "summary": "<no build panel found>",
+            "state": "inconclusive",
+            "summary": (
+                "Sublime Text did not surface a build output panel for the "
+                "Syntax Tests build variant"
+            ),
             "output": "",
             "failures": [],
         }
@@ -561,8 +577,11 @@ def _run_syntax_tests_via_build(path, timeout):
     text = panel.substr(sublime.Region(0, panel.size()))
     if not saw_content:
         return {
-            "ok": False,
-            "summary": "<no build-panel output captured>",
+            "state": "inconclusive",
+            "summary": (
+                "Syntax Tests build variant produced no output before the "
+                "timeout elapsed"
+            ),
             "output": "",
             "failures": [],
         }
@@ -580,8 +599,19 @@ def _run_syntax_tests_via_build(path, timeout):
         line for line in text.splitlines()
         if line.lstrip().startswith("FAILED")
     ]
-    ok = "assertions passed" in text and not failures
-    return {"ok": ok, "summary": summary_line, "output": text, "failures": failures}
+    if failures:
+        state = "failed"
+        summary = summary_line
+    elif "assertions passed" in text:
+        state = "passed"
+        summary = summary_line
+    else:
+        state = "inconclusive"
+        summary = (
+            "Syntax Tests build variant output did not contain a parsable "
+            "assertion summary"
+        )
+    return {"state": state, "summary": summary, "output": text, "failures": failures}
 
 
 def run_syntax_tests(path, timeout=30.0):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -395,14 +395,10 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
             r = json.loads(outcome["output"])
             self.assertEqual(r["state"], "inconclusive")
             self.assertEqual(r["failures"], [])
-            # Descriptive prose rather than an empty string or a bracketed
-            # placeholder.
-            self.assertNotEqual(r["summary"], "")
-            self.assertFalse(
-                r["summary"].startswith("<"),
-                "expected descriptive prose, got bracketed placeholder %r"
-                % r["summary"],
-            )
+            # All three build-path inconclusive branches name the build
+            # variant; pin against the shared substring so a regression
+            # to generic-but-wrong prose fails the test.
+            self.assertIn("Syntax Tests build variant", r["summary"])
         finally:
             os.unlink(path)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -179,7 +179,7 @@ class HelperTestBase(DeferrableTestCase):
 class TestResponseShape(HelperTestBase):
     """Outer MCP response contract: no outer `ok` field; `error is null`
     on success; `isError` tracks the presence of `error`. Distinct from
-    the inner `ok` some helpers return (e.g. `run_syntax_tests(...)["ok"]`)."""
+    helper-level status fields like `run_syntax_tests(...)["state"]`."""
 
     def test_success_has_no_outer_ok(self):
         resp = yield from _call_tool_yielding("print('hi')")
@@ -311,7 +311,7 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
             HEADER + "x = 1\n# ^ source.python\n",
         )
         r = yield from self._run(path)
-        self.assertTrue(r["ok"], r)
+        self.assertEqual(r["state"], "passed", r)
         self.assertEqual(r["failures"], [])
         self.assertIn("assertions passed", r["summary"])
 
@@ -324,7 +324,7 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
             + "y = 2\n# ^ keyword.control.flow\n",
         )
         r = yield from self._run(path)
-        self.assertFalse(r["ok"], r)
+        self.assertEqual(r["state"], "failed", r)
         self.assertEqual(len(r["failures"]), 1, r)
         msg = r["failures"][0]
         self.assertIn("syntax_test_mix", msg)
@@ -338,12 +338,28 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
             + "x = 1\n# ^ keyword.control.flow\n",
         )
         first = yield from self._run(path)
-        self.assertFalse(first["ok"], first)
+        self.assertEqual(first["state"], "failed", first)
         self.assertEqual(len(first["failures"]), 1, first)
         for _ in range(4):
             r = yield from self._run(path)
-            self.assertEqual(r["ok"], first["ok"])
+            self.assertEqual(r["state"], first["state"])
             self.assertEqual(len(r["failures"]), len(first["failures"]))
+
+    def test_unindexed_resource_yields_inconclusive_state(self):
+        # Path under packages_path() but pointing at a package directory
+        # that doesn't exist on disk. _to_resource_path maps it to a
+        # Packages/... URI, sublime_api.run_syntax_test reports "unable
+        # to read file", _wait_for_resource times out without the
+        # resource appearing in the index, and the API path returns the
+        # inconclusive branch rather than silently falling through to
+        # the build-panel path.
+        bogus = os.path.join(
+            sublime.packages_path(), "__sublime_mcp_unindexed__", "syntax_test_nope"
+        )
+        r = yield from self._run(bogus)
+        self.assertEqual(r["state"], "inconclusive", r)
+        self.assertEqual(r["failures"], [])
+        self.assertIn("not indexed", r["summary"])
 
     def _run(self, path):
         # Generator: callers must `yield from self._run(...)`.
@@ -362,7 +378,7 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
     """Fallback path kicks in for files outside `sublime.packages_path()`.
     The critical contract: never return a silent empty result."""
 
-    def test_outside_packages_self_describes_empty(self):
+    def test_outside_packages_describes_cause(self):
         fd, path = tempfile.mkstemp(suffix=".txt")
         os.close(fd)
         try:
@@ -377,12 +393,15 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
             outcome = _outcome(resp)
             self.assertIsNone(outcome["error"], outcome.get("error"))
             r = json.loads(outcome["output"])
-            self.assertFalse(r["ok"])
+            self.assertEqual(r["state"], "inconclusive")
             self.assertEqual(r["failures"], [])
-            # Self-describing marker rather than "".
-            self.assertTrue(
-                r["summary"].startswith("<") and r["summary"].endswith(">"),
-                "expected self-describing marker, got %r" % r["summary"],
+            # Descriptive prose rather than an empty string or a bracketed
+            # placeholder.
+            self.assertNotEqual(r["summary"], "")
+            self.assertFalse(
+                r["summary"].startswith("<"),
+                "expected descriptive prose, got bracketed placeholder %r"
+                % r["summary"],
             )
         finally:
             os.unlink(path)


### PR DESCRIPTION
`run_syntax_tests` now returns `{state, summary, output, failures}` instead of `{ok, summary, output, failures}`. `state` is `"passed"`, `"failed"`, or `"inconclusive"`; the three `<…>` placeholder strings move out of `summary` and become descriptive prose. Same inner-vs-outer-`ok` reasoning as the prior outer-`ok` removal: the inner `ok` was lossy (binary over a ternary underlying outcome) and ambiguous between assertion failures and runner errors. `state` resolves both; `summary` keeps its always-populated role; `failures` is unchanged.

`SKILL.md` is updated to match and conditions its fallback hint on `state == "inconclusive"`. The recipe (`scope_at` / `scope_at_test` / `resolve_position` for divergence triage) stays in `SKILL.md` rather than the response — single source of truth for prescriptive guidance.

Closes #25.

This PR does **not** close #17. Its three remedies (retry / actionable text / precondition guard) are all out of scope; the legibility improvements may make #17 less urgent, but adoption of any remedy is deferred pending post-merge reproduction-frequency data.

## Test plan

CI covers the contract end-to-end (passed/failed/inconclusive across both API and build paths). The new `TestRunSyntaxTestsApiPath.test_unindexed_resource_yields_inconclusive_state` is the only test that didn't already exist — it forces the API path's inconclusive branch by pointing at a Packages-rooted path with no resource on disk.