### PR TITLE
Warn against `view.set_syntax_file` with a filesystem path

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -104,7 +104,9 @@ If `state == "inconclusive"`, fall back to the "Scope at a position" recipe (`sc
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 
-`view.assign_syntax` takes a `Packages/...` resource URI, not an arbitrary filesystem path. To test a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), symlink it in first:
+`view.assign_syntax` takes a `Packages/...` resource URI, not an arbitrary filesystem path. The older `view.set_syntax_file` has the same constraint but fails silently when given a filesystem path: `view.settings().get("syntax")` echoes the assigned absolute path, ST surfaces a "file not found" popup, `view.scope_name(...)` returns `text.plain` for every position, and the Python call doesn't raise. Prefer `assign_syntax_and_wait`.
+
+To test a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), symlink it in first:
 
 ```bash
 ln -s /path/to/repo/testdata/Packages/Java \


### PR DESCRIPTION
Adds a one-paragraph callout in `skills/sublime-mcp/SKILL.md` §4 (`### Confirm which syntax ST assigned …`) flagging that `view.set_syntax_file` shares `assign_syntax`'s `Packages/...` constraint but fails silently on a filesystem path — settings reflects the absolute path, ST pops a "file not found" dialog, `scope_name` returns `text.plain`, no exception. Direct quote of the symptom set a recent caller hit before realising the older API was the wrong door.

Sibling to the silent-fallback cluster in #6 / #11 / #22 / #24: `assign_syntax_and_wait` is already the right helper to reach for; the warning steers callers there before they re-discover the trap themselves.
