### PR TITLE
Raise on run_syntax_tests runner failures

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -99,7 +99,7 @@ Branch on `state` for the assertion-run outcome:
 | `"passed"`  | runner completed; every assertion matched                                        | assertion-count headline                         | `[]`           |
 | `"failed"`  | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated      |
 
-When ST cannot complete the run, `run_syntax_tests` raises (`RuntimeError` / `TimeoutError`) and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. Known causes include the build-panel-missing case (tracked as #17), unindexed resources, and timeouts on a panel that produced no output. Fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — these answer the underlying ground-truth question without going through ST's build path.
+When ST cannot complete the run, `run_syntax_tests` raises and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. Type split: `TimeoutError` for the no-output-before-deadline case; `RuntimeError` for build-panel missing (tracked as #17), unindexed resources, and unparsable build-panel output. Fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — these answer the underlying ground-truth question without going through ST's build path.
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -55,8 +55,8 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 ```
 
 - Assign to `_` inside the snippet to get its `repr` back as `result`.
-- `error` is populated on uncaught exception; `isError` is derived from `error is not None`.
-- **Helper-level status fields are unrelated to the top-level success signal.** `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed` / `inconclusive`), not whether the MCP call succeeded.
+- `error` is populated on uncaught exception; `isError` is derived from `error is not None`. Helper failures (e.g. `run_syntax_tests` cannot complete the run) raise and surface in this same `error` field — there is no separate helper-level error channel.
+- `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed`).
 - Preloaded helpers (`scope_at`, `scope_at_test`, `resolve_position`, `run_syntax_tests`, `open_view`, `assign_syntax_and_wait`, `find_resources`, `reload_syntax`) are in scope without import.
 
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
@@ -92,15 +92,14 @@ for msg in r["failures"]:
     print(msg)
 ```
 
-Branch on `state`, not on `isError` — `state` disambiguates outcomes that `isError` collapses:
+Branch on `state` for the assertion-run outcome:
 
-| `state`          | meaning                                                                          | `summary` shape                                  | `failures`     |
-| ---------------- | -------------------------------------------------------------------------------- | ------------------------------------------------ | -------------- |
-| `"passed"`       | runner completed; every assertion matched                                        | assertion-count headline                         | `[]`           |
-| `"failed"`       | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated      |
-| `"inconclusive"` | runner could not complete the run; assertion outcomes are unknown                | descriptive prose naming the cause               | `[]`           |
+| `state`     | meaning                                                                          | `summary` shape                                  | `failures`     |
+| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------------ | -------------- |
+| `"passed"`  | runner completed; every assertion matched                                        | assertion-count headline                         | `[]`           |
+| `"failed"`  | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated      |
 
-If `state == "inconclusive"`, fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — these answer the underlying ground-truth question without going through ST's build path. Causes that surface as `inconclusive` include the build-panel-missing case (tracked as #17), unindexed resources, and timeouts on a panel that produced no output.
+When ST cannot complete the run, `run_syntax_tests` raises (`RuntimeError` / `TimeoutError`) and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. Known causes include the build-panel-missing case (tracked as #17), unindexed resources, and timeouts on a panel that produced no output. Fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — these answer the underlying ground-truth question without going through ST's build path.
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -74,9 +74,10 @@ The following names are preloaded:
   expected/actual snippet); populated only when
   `state == "failed"`. Cases where ST cannot complete the run
   (resource not yet indexed, build-panel missing, build timeout,
-  unparsable build output) raise `RuntimeError` / `TimeoutError`
-  and surface in the top-level `error` field of the MCP response —
-  the same channel any other helper failure uses. Primary path
+  unparsable build output) raise and surface in the top-level
+  `error` field of the MCP response — the same channel any other
+  helper failure uses. `TimeoutError` for the no-output-before-
+  deadline case; `RuntimeError` for the other three. Primary path
   uses `sublime_api.run_syntax_test`, which returns synchronously
   from a private ST API; falls back to the "Syntax Tests" build
   variant for paths outside `sublime.packages_path()`. The API

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -66,23 +66,24 @@ The following names are preloaded:
   `assign_syntax_and_wait` on the view first.
 - `run_syntax_tests(path, timeout=30.0) -> dict` — returns
   `{"state": str, "summary": str, "output": str, "failures": list[str]}`.
-  `state` is one of `"passed"` (all assertions matched), `"failed"`
-  (the runner completed but some assertions did not match), or
-  `"inconclusive"` (the runner could not complete the run, so
-  assertion outcomes are unknown). `summary` is a human-readable
-  description of the state — an assertion-count headline for
-  `passed`/`failed`, descriptive prose naming the cause for
-  `inconclusive`. `failures` is one entry per failed assertion with
-  ST's own diagnostic (file:row:col, "error: scope does not match",
-  then the expected/actual snippet); populated only when
-  `state == "failed"`. Primary path uses `sublime_api.run_syntax_test`,
-  which returns synchronously from a private ST API; falls back to
-  the "Syntax Tests" build variant for paths outside
-  `sublime.packages_path()`. The API path requires the file to live
-  under Packages/ (either as an absolute path rooted there, or the
-  `Packages/...` resource form); syntect-style investigations
-  typically symlink the repo's test dir into Packages/ for this
-  reason.
+  `state` is one of `"passed"` (all assertions matched) or
+  `"failed"` (the runner completed but some assertions did not
+  match). `summary` is an assertion-count headline. `failures` is
+  one entry per failed assertion with ST's own diagnostic
+  (file:row:col, "error: scope does not match", then the
+  expected/actual snippet); populated only when
+  `state == "failed"`. Cases where ST cannot complete the run
+  (resource not yet indexed, build-panel missing, build timeout,
+  unparsable build output) raise `RuntimeError` / `TimeoutError`
+  and surface in the top-level `error` field of the MCP response —
+  the same channel any other helper failure uses. Primary path
+  uses `sublime_api.run_syntax_test`, which returns synchronously
+  from a private ST API; falls back to the "Syntax Tests" build
+  variant for paths outside `sublime.packages_path()`. The API
+  path requires the file to live under Packages/ (either as an
+  absolute path rooted there, or the `Packages/...` resource
+  form); syntect-style investigations typically symlink the repo's
+  test dir into Packages/ for this reason.
 - `reload_syntax(resource_path) -> None` — force-reloads a
   `.sublime-syntax` resource. Useful when ST cached an older version
   (e.g. after an external edit via symlink).
@@ -134,10 +135,10 @@ requests). The response shape is:
 {"output": str, "result": str|null, "error": str|null}
 ```
 
-`error is null` means the snippet ran to completion. Helper-level
-status (e.g. `run_syntax_tests(...)["state"]` — passed / failed /
-inconclusive) is unrelated to the absence of `error` at the top
-level.
+`error is null` means the snippet ran to completion. Helper failures
+(e.g. `run_syntax_tests` cannot complete the run) raise and surface
+in this same `error` field — there is no separate helper-level
+error channel.
 
 ## Recipes
 
@@ -195,20 +196,16 @@ r = resolve_position(
 print("overflow:", r["overflow"], "clamped:", r["clamped"], "actual:", r["actual"])
 
 # 3. What does ST's own assertion runner say about this file?
+#    If ST cannot complete the run, run_syntax_tests raises and the
+#    snippet dies — the caller sees the cause in the top-level `error`.
 r = run_syntax_tests("/path/to/Packages/Git Formats/tests/syntax_test_git_config")
 if r["state"] == "passed":
     print("ST passes all assertions → syntect harness diverges from ST")
-elif r["state"] == "failed":
+else:
     print("ST fails these too → test data itself has the issue:")
     for msg in r["failures"]:
         print(msg)
-else:
-    print("ST runner inconclusive →", r["summary"])
 ```
-
-Note: `run_syntax_tests(...)["state"]` is the helper-level
-assertion-run outcome; unrelated to the top-level `error is None`
-success check on the MCP response.
 
 ### Reload a syntax file after an external edit
 
@@ -494,15 +491,12 @@ def _run_syntax_tests_via_api(path):
         total, messages = _sublime_api.run_syntax_test(resource)
     if _is_unable_to_read(messages):
         # Under Packages but still not indexed: don't silently fall back to
-        # the 30 s build-panel path — surface the miss to the caller.
-        return {
-            "state": "inconclusive",
-            "summary": (
-                "Sublime Text has not indexed the resource at %s" % resource
-            ),
-            "output": "\n".join(messages),
-            "failures": [],
-        }
+        # the 30 s build-panel path — surface the miss as an exception so
+        # it propagates up as the top-level MCP `error`.
+        raise RuntimeError(
+            "Sublime Text has not indexed the resource at %s: %s"
+            % (resource, "\n".join(messages))
+        )
     failures = list(messages)
     if failures:
         summary = "FAILED: %d of %d assertions failed" % (len(failures), total)
@@ -540,7 +534,7 @@ def _run_syntax_tests_via_build(path, timeout):
     # output panel. Used when sublime_api is unavailable or the path
     # isn't under Packages/. Addresses the original silent-empty-result
     # bug: require a non-empty read before considering the poll settled,
-    # and return a self-describing empty case instead of "".
+    # and raise a self-describing exception instead of returning "".
     window = sublime.active_window()
     open_view(path)
     window.run_command("build", {"variant": "Syntax Tests"})
@@ -557,15 +551,10 @@ def _run_syntax_tests_via_build(path, timeout):
                 if panel is not None:
                     break
     if panel is None:
-        return {
-            "state": "inconclusive",
-            "summary": (
-                "Sublime Text did not surface a build output panel for the "
-                "Syntax Tests build variant"
-            ),
-            "output": "",
-            "failures": [],
-        }
+        raise RuntimeError(
+            "Sublime Text did not surface a build output panel for the "
+            "Syntax Tests build variant"
+        )
     deadline = _time.time() + timeout
     saw_content = False
     last = ""
@@ -583,15 +572,10 @@ def _run_syntax_tests_via_build(path, timeout):
         _time.sleep(0.1)
     text = panel.substr(sublime.Region(0, panel.size()))
     if not saw_content:
-        return {
-            "state": "inconclusive",
-            "summary": (
-                "Syntax Tests build variant produced no output before the "
-                "timeout elapsed"
-            ),
-            "output": "",
-            "failures": [],
-        }
+        raise TimeoutError(
+            "Syntax Tests build variant produced no output before the "
+            "timeout elapsed"
+        )
     summary_line = ""
     for line in reversed(text.splitlines()):
         stripped = line.strip()
@@ -618,8 +602,7 @@ def _run_syntax_tests_via_build(path, timeout):
         state = "passed"
         summary = summary_line
     else:
-        state = "inconclusive"
-        summary = (
+        raise RuntimeError(
             "Syntax Tests build variant output did not contain a parsable "
             "assertion summary"
         )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -345,21 +345,22 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
             self.assertEqual(r["state"], first["state"])
             self.assertEqual(len(r["failures"]), len(first["failures"]))
 
-    def test_unindexed_resource_yields_inconclusive_state(self):
+    def test_unindexed_resource_raises(self):
         # Path under packages_path() but pointing at a package directory
         # that doesn't exist on disk. _to_resource_path maps it to a
         # Packages/... URI, sublime_api.run_syntax_test reports "unable
         # to read file", _wait_for_resource times out without the
-        # resource appearing in the index, and the API path returns the
-        # inconclusive branch rather than silently falling through to
-        # the build-panel path.
+        # resource appearing in the index, and the API path raises
+        # rather than silently falling through to the build-panel path.
         bogus = os.path.join(
             sublime.packages_path(), "__sublime_mcp_unindexed__", "syntax_test_nope"
         )
-        r = yield from self._run(bogus)
-        self.assertEqual(r["state"], "inconclusive", r)
-        self.assertEqual(r["failures"], [])
-        self.assertIn("not indexed", r["summary"])
+        code = "_ = run_syntax_tests(%r)\n" % bogus
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("RuntimeError", outcome["error"])
+        self.assertIn("not indexed", outcome["error"])
 
     def _run(self, path):
         # Generator: callers must `yield from self._run(...)`.
@@ -409,7 +410,7 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
         # End-to-end: drive the build path against a real failing fixture
         # and verify populated `failures`. Skipped on sessions where ST's
         # "Syntax Tests" build variant doesn't surface a panel — a known
-        # #17-shaped issue that produces `state == "inconclusive"`. The
+        # #17-shaped issue where run_syntax_tests now raises. The
         # in-namespace regex test above covers regex regressions that
         # would otherwise slip through this skip.
         fd, path = tempfile.mkstemp(suffix=".py")
@@ -425,14 +426,14 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
             )
             resp = yield from _call_tool_yielding(code)
             outcome = _outcome(resp)
-            self.assertIsNone(outcome["error"], outcome.get("error"))
-            r = json.loads(outcome["output"])
-            if r["state"] != "failed":
+            if outcome["error"] is not None:
                 self.skipTest(
-                    "build path returned state=%r; populated-output "
-                    "coverage requires the Syntax Tests build variant to "
-                    "surface a panel" % r["state"]
+                    "build path raised; populated-output coverage "
+                    "requires the Syntax Tests build variant to surface a "
+                    "panel: %s" % outcome["error"].splitlines()[-1]
                 )
+            r = json.loads(outcome["output"])
+            self.assertEqual(r["state"], "failed", r)
             self.assertGreater(len(r["failures"]), 0, r)
             self.assertIn("FAILED", r["failures"][0])
         finally:
@@ -444,21 +445,14 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
         try:
             with open(path, "w") as f:
                 f.write("just text\n")
-            code = (
-                "import json\n"
-                "_ = run_syntax_tests(%r, timeout=3.0)\n"
-                "print(json.dumps(_))\n" % path
-            )
+            code = "_ = run_syntax_tests(%r, timeout=3.0)\n" % path
             resp = yield from _call_tool_yielding(code)
             outcome = _outcome(resp)
-            self.assertIsNone(outcome["error"], outcome.get("error"))
-            r = json.loads(outcome["output"])
-            self.assertEqual(r["state"], "inconclusive")
-            self.assertEqual(r["failures"], [])
-            # All three build-path inconclusive branches name the build
-            # variant; pin against the shared substring so a regression
-            # to generic-but-wrong prose fails the test.
-            self.assertIn("Syntax Tests build variant", r["summary"])
+            self.assertIsNotNone(outcome["error"])
+            # All three build-path raise sites name the build variant;
+            # pin against the shared substring so a regression to
+            # generic-but-wrong prose fails the test.
+            self.assertIn("Syntax Tests build variant", outcome["error"])
         finally:
             os.unlink(path)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -359,7 +359,6 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
         resp = yield from _call_tool_yielding(code)
         outcome = _outcome(resp)
         self.assertIsNotNone(outcome["error"])
-        self.assertIn("RuntimeError", outcome["error"])
         self.assertIn("not indexed", outcome["error"])
 
     def _run(self, path):


### PR DESCRIPTION
Brings `run_syntax_tests` into line with the rest of the helper surface in `sublime_mcp.py`: the four "ST cannot complete the run" branches now raise instead of returning `state: "inconclusive"`. The cause surfaces in the top-level MCP `error` field — the same channel `open_view` / `assign_syntax_and_wait` / `_parse_syntax_test_header` already use — and `state` collapses to `passed | failed`.

`skills/sublime-mcp/SKILL.md` and the `TOOL_DESCRIPTION` docstring are reworded to match; the §4 state table loses the `inconclusive` row and the §3 helper-vs-top-level disambiguation can come out (the two no longer overlap).
