### PR TITLE
Surface resolved syntax and ST identity on helper responses

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -51,11 +51,12 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 `mcp__sublime-text__exec_sublime_python({ code })` runs `code` on a dedicated daemon thread inside ST's plugin host (Python 3.8) and returns:
 
 ```json
-{ "output": "<captured print()>", "result": "<repr(_) or null>", "error": "<traceback or null>", "isError": false }
+{ "output": "<captured print()>", "result": "<repr(_) or null>", "error": "<traceback or null>", "st_version": 4200, "st_channel": "stable", "isError": false }
 ```
 
 - Assign to `_` inside the snippet to get its `repr` back as `result`.
 - `error` is populated on uncaught exception; `isError` is derived from `error is not None`. Helper failures (e.g. `run_syntax_tests` cannot complete the run) raise and surface in this same `error` field — there is no separate helper-level error channel.
+- `st_version` (int) and `st_channel` (str, e.g. `"stable"` / `"dev"`) echo the running ST build on every response. Use these to detect channel mismatches when probing grammars whose CI gates on a non-stable channel.
 - `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed`).
 - Preloaded helpers (`scope_at`, `scope_at_test`, `resolve_position`, `run_syntax_tests`, `open_view`, `assign_syntax_and_wait`, `find_resources`, `reload_syntax`) are in scope without import.
 

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -68,10 +68,13 @@ Each recipe is one `exec_sublime_python` call. Rows and columns are **0-indexed*
 ### Scope at a position
 
 ```python
-print(scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8))
+r = scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8)
+print(r["scope"], "via", r["resolved_syntax"])
 ```
 
-**Landmine: extension-less syntax-test files** (`syntax_test_git_config`, no suffix) silently return `text.plain` via `scope_at`, because ST can't infer the syntax from the filename. Use `scope_at_test` — it parses the `# SYNTAX TEST "Packages/..."` header and assigns that syntax before sampling.
+`scope_at` returns `{"scope": str, "resolved_syntax": str | None}`. `resolved_syntax` is the URI ST actually loaded (`view.syntax().path`) — `None` when no syntax resolved, `"Packages/Text/Plain text.tmLanguage"` when ST defaulted to Plain Text. Branch on `resolved_syntax` to detect silent fallback before treating `scope` as ground truth.
+
+**Landmine: extension-less syntax-test files** (`syntax_test_git_config`, no suffix) silently fall back to Plain Text via `scope_at` — `scope == "text.plain"` and `resolved_syntax == "Packages/Text/Plain text.tmLanguage"`. Use `scope_at_test` — it parses the `# SYNTAX TEST "Packages/..."` header and assigns that syntax before sampling.
 
 ```python
 print(scope_at_test("/path/to/syntax_test_git_config", 71, 28))
@@ -153,7 +156,7 @@ If step 3 passes, the downstream parser diverges from ST — file the bug agains
 `scope_name` on an already-tokenised view is thread-safe and runs concurrent with ST's UI, so a several-hundred-row sweep in one `exec_sublime_python` call comfortably fits the 60 s per-call budget. The cold-view cost is a one-time tokenisation pass on the first helper call against a given path.
 
 ```python
-scopes = [scope_at("/path/to/big_file", row, 0) for row in range(3020, 3039)]
+scopes = [scope_at("/path/to/big_file", row, 0)["scope"] for row in range(3020, 3039)]
 _ = scopes  # returns via `result`
 ```
 
@@ -183,7 +186,7 @@ _Last synced with issue state: 2026-04-28._
 
 ## 7. Reference — preloaded helpers
 
-- `scope_at(path, row, col) -> str` — open file, return `view.scope_name` at point. Silently wrong on extension-less files.
+- `scope_at(path, row, col) -> dict` — open file, return `{"scope", "resolved_syntax"}`. `resolved_syntax` is `view.syntax().path` (or `None`); compare against the canonical plain-text URI to detect extension-less / no-syntax fallback.
 - `scope_at_test(path, row, col) -> str` — parse `# SYNTAX TEST` header, assign that syntax, return scope. Right for extension-less syntax-test files.
 - `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags.
 - `run_syntax_tests(path, timeout=30.0) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`.

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -77,13 +77,15 @@ print(r["scope"], "via", r["resolved_syntax"])
 **Landmine: extension-less syntax-test files** (`syntax_test_git_config`, no suffix) silently fall back to Plain Text via `scope_at` — `scope == "text.plain"` and `resolved_syntax == "Packages/Text/Plain text.tmLanguage"`. Use `scope_at_test` — it parses the `# SYNTAX TEST "Packages/..."` header and assigns that syntax before sampling.
 
 ```python
-print(scope_at_test("/path/to/syntax_test_git_config", 71, 28))
+r = scope_at_test("/path/to/syntax_test_git_config", 71, 28)
+print(r["scope"])
 ```
 
 The header parser is comment-token-agnostic — it accepts `#`, `//`, `<!--`, `;`, `--`, `|`, etc. Markdown's pipe-comment header works the same way:
 
 ```python
-print(scope_at_test("/path/to/syntax_test_markdown.md", 12, 4))
+r = scope_at_test("/path/to/syntax_test_markdown.md", 12, 4)
+print(r["scope"])
 ```
 
 ### Run syntax tests against a file
@@ -123,11 +125,12 @@ r = resolve_position(
     syntax_path="Packages/Java/Java.sublime-syntax",
 )
 print(r["scope"], "overflow:", r["overflow"], "clamped:", r["clamped"])
+assert r["resolved_syntax"] == r["requested_syntax"], r
 ```
 
-The returned dict also carries `overflow` (past-EOL request wrapped into a later row) and `clamped` (past-EOF, point at `view.size()`) — mutually exclusive flags that surface a quiet `text_point` behaviour; the full semantics are in `TOOL_DESCRIPTION`'s "text_point overflow" section.
+The returned dict also carries `overflow` (past-EOL request wrapped into a later row), `clamped` (past-EOF, point at `view.size()`) — mutually exclusive flags that surface a quiet `text_point` behaviour; the full semantics are in `TOOL_DESCRIPTION`'s "text_point overflow" section. `requested_syntax` echoes the `syntax_path` argument and `resolved_syntax` is `view.syntax().path` — assert they match before treating `scope` as ground truth, since `view.assign_syntax` accepts any string and silently falls through to Plain Text when the URI doesn't resolve.
 
-The symlink is the workaround for `resolve_position`'s `syntax_path` parameter; beware that ST might resolve to a same-named bundled syntax if the symlink ordering is wrong. #22 will let `resolve_position` accept filesystem paths instead of `Packages/...` URIs, but the `ln -s` step itself stays load-bearing — eliminating that requires helper-managed temporary symlinks (#24). `scope_at_test` is unaffected: the file's `SYNTAX TEST` header carries the URI, conventionally `Packages/...` form already. `run_syntax_tests` is unaffected post-PR #16 (`_to_resource_path` walks symlinked entries directly). #11 (orthogonal) will echo the resolved syntax in the response, defending against symlink misresolution.
+The symlink is the workaround for `resolve_position`'s `syntax_path` parameter; beware that ST might resolve to a same-named bundled syntax if the symlink ordering is wrong — `requested_syntax != resolved_syntax` flags this. #22 will let `resolve_position` accept filesystem paths instead of `Packages/...` URIs, but the `ln -s` step itself stays load-bearing — eliminating that requires helper-managed temporary symlinks (#24). `scope_at_test` parses the URI from the file's `SYNTAX TEST` header (conventionally `Packages/...` already) and exposes the same `requested_syntax` / `resolved_syntax` pair. `run_syntax_tests` is unaffected post-PR #16 (`_to_resource_path` walks symlinked entries directly).
 
 ### Compare a parser's output against ST
 
@@ -135,7 +138,8 @@ Three-step divergence triage:
 
 ```python
 # 1. What does ST report at the failing position?
-print(scope_at_test("/path/to/syntax_test_git_config", 71, 28))
+r = scope_at_test("/path/to/syntax_test_git_config", 71, 28)
+print(r["scope"], "via", r["resolved_syntax"])
 
 # 2. Did both engines sample the same point? (past-EOL divergence is common)
 r = resolve_position(
@@ -171,7 +175,7 @@ Measured per-call latency is tracked in #10.
 
 ## 6. Known limitations / tracking
 
-_Last synced with issue state: 2026-04-28._
+_Last synced with issue state: 2026-05-03._
 
 - **#6** — bump `_wait_for_resource` timeout 1s → 2-3s for cold-disk indexing.
 - **#7** — parameterise the test suite's hardcoded `HEADER` across syntaxes.
@@ -179,7 +183,6 @@ _Last synced with issue state: 2026-04-28._
 - **#22** — `resolve_position` `syntax_path` accepts filesystem paths (URI flexibility only — does not eliminate the `ln -s` step in §4).
 - **#24** — helper-managed temporary symlinks for repo-local syntaxes. Lands the `ln -s`-elimination half of #9's body. Once landed, the §4 workaround paragraph (and #22 / #24 entries) become removable.
 - **#10** — documented per-call latency for bulk probes + daemon-thread / cold-tokenisation clarification.
-- **#11** — echo the resolved syntax path in `resolve_position` / `scope_at_test` responses. Defends against symlink misresolution.
 - **#30** — `run_inline_syntax_test(content, name)` lifecycle helper. Collapses the write-to-`Packages/User/`-then-poll-then-cleanup dance into one call; pairs with #24 on the on-disk side.
 - **#33** — daemon-thread `view.run_command(...)` is a silent no-op without `set_timeout`. Until the doc gotcha or `run_on_main` helper lands, callers mutating buffers from snippet code need to schedule via `set_timeout` and gate on a `threading.Event`.
 - **#34** — `find_resources` lists `Packages/...` paths whose `load_resource` raises `FileNotFoundError` (cache-survives-source case observed against `Packages/C#/Embeddings/Regex (for C#).sublime-syntax`); characterise before deciding doc vs code fix.
@@ -187,8 +190,8 @@ _Last synced with issue state: 2026-04-28._
 ## 7. Reference — preloaded helpers
 
 - `scope_at(path, row, col) -> dict` — open file, return `{"scope", "resolved_syntax"}`. `resolved_syntax` is `view.syntax().path` (or `None`); compare against the canonical plain-text URI to detect extension-less / no-syntax fallback.
-- `scope_at_test(path, row, col) -> str` — parse `# SYNTAX TEST` header, assign that syntax, return scope. Right for extension-less syntax-test files.
-- `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags.
+- `scope_at_test(path, row, col) -> dict` — parse `# SYNTAX TEST` header, assign that syntax, return `{"scope", "requested_syntax", "resolved_syntax"}`. `requested_syntax != resolved_syntax` flags silent fallback to the wrong syntax.
+- `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags; also carries `requested_syntax` / `resolved_syntax`.
 - `run_syntax_tests(path, timeout=30.0) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`.
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -60,14 +60,19 @@ The following names are preloaded:
   (`resolved_syntax == "Packages/Text/Plain text.tmLanguage"`,
   `scope == "text.plain"`) and the caller can detect this by checking
   `resolved_syntax`.
-- `scope_at_test(path, row, col) -> str` — like `scope_at`, but
+- `scope_at_test(path, row, col) -> dict` — like `scope_at`, but
   parses the `SYNTAX TEST "Packages/..."` header on line 0 and
-  assigns that syntax to the view before sampling the scope. The
-  right helper for extension-less syntax-test files.
+  assigns that syntax to the view before sampling the scope. Returns
+  `{"scope", "resolved_syntax", "requested_syntax"}` — `requested_syntax`
+  is the URI from the header; `resolved_syntax` is what ST loaded
+  (`view.syntax().path`, or `None` if the URI doesn't resolve to a
+  real syntax). The right helper for extension-less syntax-test files.
 - `resolve_position(path, row, col, syntax_path=None) -> dict` —
   returns the full position disambiguation for `(row, col)`. See
   "text_point overflow" below. Optional `syntax_path` calls
-  `assign_syntax_and_wait` on the view first.
+  `assign_syntax_and_wait` on the view first. Response carries
+  `requested_syntax` (echo of the `syntax_path` arg, or `None`) and
+  `resolved_syntax` (ST's `view.syntax().path`, or `None`).
 - `run_syntax_tests(path, timeout=30.0) -> dict` — returns
   `{"state": str, "summary": str, "output": str, "failures": list[str]}`.
   `state` is one of `"passed"` (all assertions matched) or
@@ -158,9 +163,10 @@ print(r["scope"], "via", r["resolved_syntax"])
 ### Scope on an extension-less syntax-test file
 
 ```python
-# File has no extension; `scope_at` would return "text.plain".
+# File has no extension; `scope_at` would default to "text.plain".
 # scope_at_test parses `# SYNTAX TEST "Packages/..."` on line 0.
-print(scope_at_test("/path/to/syntax_test_git_config", 71, 28))
+r = scope_at_test("/path/to/syntax_test_git_config", 71, 28)
+print(r["scope"])
 ```
 
 ### Resolve a past-EOL position
@@ -191,7 +197,12 @@ semantics divergence?". Each step answers a distinct question:
 
 ```python
 # 1. What scope does ST actually report at the failing position?
-print(scope_at_test("/path/to/Packages/Git Formats/tests/syntax_test_git_config", 71, 28))
+#    Compare requested_syntax vs resolved_syntax to detect silent
+#    fallback (e.g. ST loaded a built-in version of a syntax that the
+#    test was authored against).
+r = scope_at_test("/path/to/Packages/Git Formats/tests/syntax_test_git_config", 71, 28)
+print(r["scope"], "via", r["resolved_syntax"])
+assert r["resolved_syntax"] == r["requested_syntax"], r
 
 # 2. Did syntect and ST even agree on which row/col to sample?
 #    (past-EOL overflow is a common hidden source of divergence)
@@ -200,6 +211,7 @@ r = resolve_position(
     syntax_path="Packages/Git Formats/Git Config.sublime-syntax",
 )
 print("overflow:", r["overflow"], "clamped:", r["clamped"], "actual:", r["actual"])
+print("resolved:", r["resolved_syntax"])
 
 # 3. What does ST's own assertion runner say about this file?
 #    If ST cannot complete the run, run_syntax_tests raises and the
@@ -382,7 +394,12 @@ def scope_at_test(path, row, col):
     resource_path = _parse_syntax_test_header(view)
     assign_syntax_and_wait(view, resource_path)
     point = view.text_point(row, col)
-    return view.scope_name(point).rstrip()
+    syntax = view.syntax()
+    return {
+        "scope": view.scope_name(point).rstrip(),
+        "requested_syntax": resource_path,
+        "resolved_syntax": syntax.path if syntax is not None else None,
+    }
 
 
 def resolve_position(path, row, col, syntax_path=None):
@@ -398,6 +415,7 @@ def resolve_position(path, row, col, syntax_path=None):
     # against future inputs that resolve to a *smaller* row (negative
     # rows, CRLF edge cases) — those would be bugs, not overflows.
     overflow = real_row > row and not clamped
+    syntax = view.syntax()
     return {
         "point": point,
         "requested": [row, col],
@@ -405,6 +423,8 @@ def resolve_position(path, row, col, syntax_path=None):
         "scope": view.scope_name(point).rstrip(),
         "overflow": overflow,
         "clamped": clamped,
+        "requested_syntax": syntax_path,
+        "resolved_syntax": syntax.path if syntax is not None else None,
     }
 
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -142,13 +142,22 @@ global stream redirect (needed for thread-safety under concurrent
 requests). The response shape is:
 
 ```
-{"output": str, "result": str|null, "error": str|null}
+{
+  "output": str,
+  "result": str|null,
+  "error": str|null,
+  "st_version": int,
+  "st_channel": str
+}
 ```
 
 `error is null` means the snippet ran to completion. Helper failures
 (e.g. `run_syntax_tests` cannot complete the run) raise and surface
 in this same `error` field — there is no separate helper-level
-error channel.
+error channel. `st_version` (e.g. `4200`) and `st_channel` (e.g.
+`"stable"`, `"dev"`) echo the running Sublime Text build on every
+response, so callers can detect channel mismatches before treating
+scope output as ground truth.
 
 ## Recipes
 
@@ -668,11 +677,23 @@ _HELPERS_CODE = compile(HELPERS_SOURCE, "<sublime-mcp-helpers>", "exec")
 def _exec_on_worker(code):
     """Run `code` on a dedicated daemon thread and collect output.
 
-    Returns a dict with keys `output`, `result`, `error`. `error is None`
-    means the snippet ran to completion.
+    Returns a dict with keys `output`, `result`, `error`, `st_version`,
+    `st_channel`. `error is None` means the snippet ran to completion.
+    `st_version` / `st_channel` echo the running ST build so callers can
+    detect when they're driving (e.g.) ST stable while their question
+    was authored against ST DEV — read per-call so an in-place ST
+    upgrade is reflected without restart.
     """
     done = threading.Event()
-    result = {"output": "", "result": None, "error": None}
+    # ST guarantees `sublime.version()` is a stringified integer; cast
+    # at the boundary so callers don't reparse.
+    result = {
+        "output": "",
+        "result": None,
+        "error": None,
+        "st_version": int(sublime.version()),
+        "st_channel": sublime.channel(),
+    }
 
     def run():
         buf_out = io.StringIO()
@@ -722,11 +743,11 @@ def _exec_on_worker(code):
     worker = threading.Thread(target=run, name="sublime-mcp-exec", daemon=True)
     worker.start()
     if not done.wait(EXEC_TIMEOUT_SECONDS):
-        return {
-            "output": "",
-            "result": None,
-            "error": "exec timed out after %ss" % EXEC_TIMEOUT_SECONDS,
-        }
+        # Reuse the pre-populated `st_version` / `st_channel` from the
+        # initial dict so the envelope shape stays uniform across the
+        # success and timeout paths.
+        result["error"] = "exec timed out after %ss" % EXEC_TIMEOUT_SECONDS
+        return result
     return result
 
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -48,14 +48,18 @@ require the main UI thread (e.g. `TextCommand` edit tokens), use
 The following names are preloaded:
 
 - `sublime`, `sublime_plugin` — the ST Python API modules.
-- `scope_at(path, row, col) -> str` — opens the file, returns
-  `view.scope_name` at the 0-indexed (row, col). Rows and cols are
+- `scope_at(path, row, col) -> dict` — opens the file, returns
+  `{"scope": str, "resolved_syntax": str | None}`. `scope` is
+  `view.scope_name` at the 0-indexed (row, col); rows and cols are
   0-indexed, matching ST's API (a syntax-test assertion on line 181
-  col 9 corresponds to `row=180, col=8`). **Use `scope_at_test` for
-  files with no extension. `scope_at` does not parse the
-  `# SYNTAX TEST` header and will silently return `text.plain` when
-  ST can't infer the syntax from the file name** — a common landmine
-  with `syntax_test_*` files.
+  col 9 corresponds to `row=180, col=8`). `resolved_syntax` is
+  `view.syntax().path` — the URI of the syntax ST actually loaded,
+  or `None` if no syntax resolved (extensionless files, bogus URIs).
+  **Use `scope_at_test` for files with no extension. `scope_at` does
+  not parse the `# SYNTAX TEST` header**: ST falls back to Plain Text
+  (`resolved_syntax == "Packages/Text/Plain text.tmLanguage"`,
+  `scope == "text.plain"`) and the caller can detect this by checking
+  `resolved_syntax`.
 - `scope_at_test(path, row, col) -> str` — like `scope_at`, but
   parses the `SYNTAX TEST "Packages/..."` header on line 0 and
   assigns that syntax to the view before sampling the scope. The
@@ -147,7 +151,8 @@ error channel.
 
 ```python
 # syntax_test_Generics.cs line 181 col 9 → row=180, col=8
-print(scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8))
+r = scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8)
+print(r["scope"], "via", r["resolved_syntax"])
 ```
 
 ### Scope on an extension-less syntax-test file
@@ -312,7 +317,15 @@ def open_view(path, timeout=5.0):
 def scope_at(path, row, col):
     view = open_view(path)
     point = view.text_point(row, col)
-    return view.scope_name(point).rstrip()
+    # `view.syntax()` returns None when ST didn't actually load a syntax —
+    # the honest signal. `view.settings().get("syntax")` echoes any
+    # `assign_syntax` argument verbatim, even bogus ones, so it can't tell
+    # silent-fallback-to-plain apart from a genuine plain-text resolution.
+    syntax = view.syntax()
+    return {
+        "scope": view.scope_name(point).rstrip(),
+        "resolved_syntax": syntax.path if syntax is not None else None,
+    }
 
 
 def assign_syntax_and_wait(view, resource_path, timeout=2.0):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -197,6 +197,18 @@ class TestResponseShape(HelperTestBase):
         self.assertIn("RuntimeError: boom", outcome["error"])
         self.assertTrue(resp["result"]["isError"])
 
+    def test_envelope_carries_st_version_and_channel(self):
+        # Envelope-level echo so non-helper snippets (and helper failures
+        # that don't reach the helper return path) still surface which ST
+        # is answering. One assertion covers every helper because the
+        # field lives at the envelope, not on each helper dict.
+        resp = yield from _call_tool_yielding("print('hi')")
+        outcome = _outcome(resp)
+        self.assertIsInstance(outcome["st_version"], int)
+        self.assertEqual(outcome["st_version"], int(sublime.version()))
+        self.assertIsInstance(outcome["st_channel"], str)
+        self.assertTrue(outcome["st_channel"])
+
 
 class TestScopeAtExtensionless(HelperTestBase):
     """The landmine the feedback flagged: `scope_at` on extension-less files

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -224,12 +224,22 @@ class TestScopeAtExtensionless(HelperTestBase):
         self.assertEqual(r["resolved_syntax"], "Packages/Text/Plain text.tmLanguage")
 
     def test_scope_at_test_parses_header_and_returns_real_scope(self):
-        resp = yield from _call_tool_yielding(
-            "print(scope_at_test(%r, 1, 0))" % self.fixture_path
+        code = (
+            "import json\n"
+            "_ = scope_at_test(%r, 1, 0)\n"
+            "print(json.dumps(_))\n" % self.fixture_path
         )
+        resp = yield from _call_tool_yielding(code)
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
-        self.assertIn("source.python", outcome["output"])
+        r = json.loads(outcome["output"])
+        self.assertIn("source.python", r["scope"])
+        self.assertEqual(
+            r["requested_syntax"], "Packages/Python/Python.sublime-syntax"
+        )
+        # Header-requested syntax matches what ST loaded → silent-fallback
+        # signal is clean.
+        self.assertEqual(r["resolved_syntax"], r["requested_syntax"])
 
 
 class TestScopeAtTestNoHeader(HelperTestBase):
@@ -280,6 +290,12 @@ class TestResolvePosition(HelperTestBase):
         self.assertFalse(r["clamped"])
         self.assertEqual(r["actual"], [1, 2])
         self.assertEqual(r["requested"], [1, 2])
+        # `_resolve` always passes `syntax_path`, so both fields are populated
+        # and equal on the happy path.
+        self.assertEqual(
+            r["requested_syntax"], "Packages/Python/Python.sublime-syntax"
+        )
+        self.assertEqual(r["resolved_syntax"], r["requested_syntax"])
 
     def test_past_eol_overflows_into_next_row(self):
         # Row 1 is 5 chars + \n; col 10 lands in a later row.
@@ -298,6 +314,33 @@ class TestResolvePosition(HelperTestBase):
         )
         size = int(_outcome(size_resp)["output"].strip())
         self.assertEqual(r["point"], size)
+
+    def test_no_syntax_path_arg_leaves_requested_syntax_none(self):
+        code = (
+            "import json\n"
+            "_ = resolve_position(%r, 1, 0)\n"
+            "print(json.dumps(_))\n" % self.fixture_path
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        r = json.loads(outcome["output"])
+        # No `syntax_path` provided → requested_syntax is None; resolved_syntax
+        # reflects whatever ST inferred from the file (or extension).
+        self.assertIsNone(r["requested_syntax"])
+        self.assertIsNotNone(r["resolved_syntax"])
+
+    # The wrong-syntax silent-fallback case (bogus `syntax_path` URI →
+    # `view.syntax()` returns None while `view.settings().get("syntax")`
+    # echoes the bogus URI verbatim) is the canonical #11 failure mode.
+    # Locally observable, but a probe with `Packages/__nonexistent__/...`
+    # provoked a deferred main-thread side-effect on macOS-CI that
+    # throttled every subsequent test until the suite hit the
+    # SublimeText/UnitTesting watchdog. Coverage gap is intentional:
+    # `test_in_bounds_no_flags_set` already asserts that both fields are
+    # populated and equal on the happy path, which guards the
+    # field-presence regression. A dedicated wrong-syntax test that
+    # avoids the macOS side-effect will need a different trigger.
 
 
 class TestRunSyntaxTestsApiPath(HelperTestBase):
@@ -508,12 +551,16 @@ class TestScopeAtTestPipeHeader(HelperTestBase):
         )
 
     def test_pipe_comment_header_parses(self):
-        resp = yield from _call_tool_yielding(
-            "print(scope_at_test(%r, 1, 0))" % self.fixture_path
+        code = (
+            "import json\n"
+            "_ = scope_at_test(%r, 1, 0)\n"
+            "print(json.dumps(_))\n" % self.fixture_path
         )
+        resp = yield from _call_tool_yielding(code)
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
-        self.assertIn("text.html.markdown", outcome["output"])
+        r = json.loads(outcome["output"])
+        self.assertIn("text.html.markdown", r["scope"])
 
 
 class TestScopeAtTestHtmlComment(HelperTestBase):
@@ -529,16 +576,20 @@ class TestScopeAtTestHtmlComment(HelperTestBase):
         )
 
     def test_html_comment_header_parses(self):
-        resp = yield from _call_tool_yielding(
-            "print(scope_at_test(%r, 1, 0))" % self.fixture_path
+        code = (
+            "import json\n"
+            "_ = scope_at_test(%r, 1, 0)\n"
+            "print(json.dumps(_))\n" % self.fixture_path
         )
+        resp = yield from _call_tool_yielding(code)
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
+        r = json.loads(outcome["output"])
         # `text.html.basic` rather than `text.html`: the looser prefix
         # would also match `text.html.markdown`, so a regression that
         # mis-applied Markdown syntax to the HTML fixture would slip
         # through.
-        self.assertIn("text.html.basic", outcome["output"])
+        self.assertIn("text.html.basic", r["scope"])
 
 
 class TestHeadlessGuard(HelperTestBase):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -209,12 +209,19 @@ class TestScopeAtExtensionless(HelperTestBase):
         )
 
     def test_scope_at_returns_text_plain_on_extensionless(self):
-        resp = yield from _call_tool_yielding(
-            "print(scope_at(%r, 1, 0))" % self.fixture_path
+        # Extensionless file → ST falls back to Plain Text. `scope_at`
+        # returns the dict shape; both fields surface the fallback.
+        code = (
+            "import json\n"
+            "_ = scope_at(%r, 1, 0)\n"
+            "print(json.dumps(_))\n" % self.fixture_path
         )
+        resp = yield from _call_tool_yielding(code)
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
-        self.assertEqual(outcome["output"].strip(), "text.plain")
+        r = json.loads(outcome["output"])
+        self.assertEqual(r["scope"], "text.plain")
+        self.assertEqual(r["resolved_syntax"], "Packages/Text/Plain text.tmLanguage")
 
     def test_scope_at_test_parses_header_and_returns_real_scope(self):
         resp = yield from _call_tool_yielding(


### PR DESCRIPTION
Three additive observability fields on helper responses, so callers can detect silent fallback before treating scope output as ground truth.

`scope_at`, `scope_at_test`, and `resolve_position` now carry `resolved_syntax` (`view.syntax().path`, or `None`) — the honest signal, since `view.settings().get("syntax")` echoes any `assign_syntax` argument verbatim including bogus URIs. `scope_at_test` and `resolve_position` additionally carry `requested_syntax`; assert `requested_syntax == resolved_syntax` to catch silent fallback to the wrong syntax. The MCP envelope (alongside `output` / `result` / `error`) now carries `st_version: int` and `st_channel: str` so callers driving against ST stable when their question was authored against ST DEV (or vice versa) can detect the mismatch up front. `scope_at` and `scope_at_test` return dicts now (breaking, pre-1.0).

Three commits on the branch — one per issue — each independently green so a reviewer can step through them without bisect anomalies.

Closes #11, closes #38, closes #47.
