### PR TITLE
Drop dead Syntax Tests build-panel fallback (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Two suites, both running inside Sublime Text via the
   `ok` dropped, `error` populated on exception), `scope_at` vs
   `scope_at_test` on extension-less files, `resolve_position`'s
   overflow / clamped matrix, `run_syntax_tests` via
-  `sublime_api.run_syntax_test` and the build-panel fallback, and
+  `sublime_api.run_syntax_test` (and its outside-Packages raise), and
   `_to_resource_path` edge cases.
 
 ### Locally

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -105,7 +105,7 @@ Branch on `state` for the assertion-run outcome:
 | `"passed"`  | runner completed; every assertion matched                                        | assertion-count headline                         | `[]`           |
 | `"failed"`  | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated      |
 
-When ST cannot complete the run, `run_syntax_tests` raises and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. Type split: `TimeoutError` for the no-output-before-deadline case; `RuntimeError` for build-panel missing (tracked as #17), unindexed resources, and unparsable build-panel output. Fall back to the "Scope at a position" recipe (`scope_at` / `scope_at_test`) or "Confirm which syntax ST assigned (and handle repo-local syntaxes)" (`resolve_position`) — these answer the underlying ground-truth question without going through ST's build path.
+When ST cannot complete the run, `run_syntax_tests` raises `RuntimeError` and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. The reachable causes are: resource not yet indexed, path outside `sublime.packages_path()` (symlink it in first — see "Confirm which syntax ST assigned (and handle repo-local syntaxes)" below), and the private `sublime_api.run_syntax_test` missing on this ST build. For ground-truth questions that don't need the assertion runner, fall back to `scope_at` / `scope_at_test` or `resolve_position`.
 
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 
@@ -131,7 +131,7 @@ assert r["resolved_syntax"] == r["requested_syntax"], r
 
 The returned dict also carries `overflow` (past-EOL request wrapped into a later row), `clamped` (past-EOF, point at `view.size()`) — mutually exclusive flags that surface a quiet `text_point` behaviour; the full semantics are in `TOOL_DESCRIPTION`'s "text_point overflow" section. `requested_syntax` echoes the `syntax_path` argument and `resolved_syntax` is `view.syntax().path` — assert they match before treating `scope` as ground truth, since `view.assign_syntax` accepts any string and silently falls through to Plain Text when the URI doesn't resolve.
 
-The symlink is the workaround for `resolve_position`'s `syntax_path` parameter; beware that ST might resolve to a same-named bundled syntax if the symlink ordering is wrong — `requested_syntax != resolved_syntax` flags this. #22 will let `resolve_position` accept filesystem paths instead of `Packages/...` URIs, but the `ln -s` step itself stays load-bearing — eliminating that requires helper-managed temporary symlinks (#24). `scope_at_test` parses the URI from the file's `SYNTAX TEST` header (conventionally `Packages/...` already) and exposes the same `requested_syntax` / `resolved_syntax` pair. `run_syntax_tests` is unaffected post-PR #16 (`_to_resource_path` walks symlinked entries directly).
+The symlink is the workaround for `resolve_position`'s `syntax_path` parameter and for `run_syntax_tests` (paths outside the Packages tree raise — there is no fallback, see #51); beware that ST might resolve to a same-named bundled syntax if the symlink ordering is wrong — `requested_syntax != resolved_syntax` flags this. #22 will let `resolve_position` accept filesystem paths instead of `Packages/...` URIs, but the `ln -s` step itself stays load-bearing — eliminating that requires helper-managed temporary symlinks (#24). `scope_at_test` parses the URI from the file's `SYNTAX TEST` header (conventionally `Packages/...` already) and exposes the same `requested_syntax` / `resolved_syntax` pair.
 
 ### Compare a parser's output against ST
 
@@ -193,7 +193,7 @@ _Last synced with issue state: 2026-05-03._
 - `scope_at(path, row, col) -> dict` — open file, return `{"scope", "resolved_syntax"}`. `resolved_syntax` is `view.syntax().path` (or `None`); compare against the canonical plain-text URI to detect extension-less / no-syntax fallback.
 - `scope_at_test(path, row, col) -> dict` — parse `# SYNTAX TEST` header, assign that syntax, return `{"scope", "requested_syntax", "resolved_syntax"}`. `requested_syntax != resolved_syntax` flags silent fallback to the wrong syntax.
 - `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags; also carries `requested_syntax` / `resolved_syntax`.
-- `run_syntax_tests(path, timeout=30.0) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`.
+- `run_syntax_tests(path) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`. Path must resolve under `sublime.packages_path()` (directly or via a symlink in that directory); paths outside the Packages tree raise.
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.
 - `find_resources(pattern) -> list[str]` — wrap `sublime.find_resources`.

--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -83,18 +83,18 @@ macOS paths shown — adjust for Linux's `~/.config/sublime-text/Packages/` or y
 ln -s /path/to/your/Packages/Markdown \
       ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
 
-# Step 2. Call run_syntax_tests with the *target path* — the input form
-# that triggered <no build panel found> on pre-fix code. The symlink-
-# walk now reverse-maps it to Packages/__sublime_mcp_verify__/...
+# Step 2. Call run_syntax_tests with the *target path* (outside the
+# Packages tree); the symlink-walk reverse-maps it to
+# Packages/__sublime_mcp_verify__/...
 curl -s -X POST http://127.0.0.1:47823/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"r = run_syntax_tests(\"/path/to/your/Packages/Markdown/tests/syntax_test_markdown.md\"); print(r[\"summary\"])"}}}'
 # Success: `summary` is a numeric "N assertions passed" or
-# "FAILED: M of N assertions failed". Explicitly NOT
-# "<no build panel found>" (the API path didn't fire — _to_resource_path
-# returned None) and NOT "<resource not indexed by Sublime Text>" (the
-# API path ran but ST's resource indexer disagreed with the
-# reconstructed URI).
+# "FAILED: M of N assertions failed". Explicitly NOT a top-level
+# `error` carrying "is not under sublime.packages_path()" (the
+# symlink-walk failed to reverse-map) or "Sublime Text has not
+# indexed the resource" (mapped, but ST's resource indexer disagreed
+# with the reconstructed URI).
 
 # Step 3. Cleanup (do not skip). unlink, NOT rm -r / rm -rf — those
 # follow the symlink and would delete the target's contents.

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -73,7 +73,7 @@ The following names are preloaded:
   `assign_syntax_and_wait` on the view first. Response carries
   `requested_syntax` (echo of the `syntax_path` arg, or `None`) and
   `resolved_syntax` (ST's `view.syntax().path`, or `None`).
-- `run_syntax_tests(path, timeout=30.0) -> dict` — returns
+- `run_syntax_tests(path) -> dict` — returns
   `{"state": str, "summary": str, "output": str, "failures": list[str]}`.
   `state` is one of `"passed"` (all assertions matched) or
   `"failed"` (the runner completed but some assertions did not
@@ -82,18 +82,12 @@ The following names are preloaded:
   (file:row:col, "error: scope does not match", then the
   expected/actual snippet); populated only when
   `state == "failed"`. Cases where ST cannot complete the run
-  (resource not yet indexed, build-panel missing, build timeout,
-  unparsable build output) raise and surface in the top-level
-  `error` field of the MCP response — the same channel any other
-  helper failure uses. `TimeoutError` for the no-output-before-
-  deadline case; `RuntimeError` for the other three. Primary path
-  uses `sublime_api.run_syntax_test`, which returns synchronously
-  from a private ST API; falls back to the "Syntax Tests" build
-  system for paths outside `sublime.packages_path()`. The API
-  path requires the file to live under Packages/ (either as an
-  absolute path rooted there, or the `Packages/...` resource
-  form); syntect-style investigations typically symlink the repo's
-  test dir into Packages/ for this reason.
+  (resource not yet indexed, path outside `sublime.packages_path()`,
+  private `sublime_api.run_syntax_test` missing) raise
+  `RuntimeError`, surfaced in the top-level `error` field of the
+  MCP response — the same channel any other helper failure uses.
+  Files outside Packages/ must be symlinked in (the helper walks
+  symlinks); see SKILL.md section 4.
 - `reload_syntax(resource_path) -> None` — force-reloads a
   `.sublime-syntax` resource. Useful when ST cached an older version
   (e.g. after an external edit via symlink).
@@ -267,15 +261,13 @@ print(v.file_name(), v.sel()[0], v.scope_name(v.sel()[0].a))
   `resolve_position` / `run_syntax_tests` / `open_view`.
   `find_resources` uses ST's `Packages/...` virtual paths, and
   `run_syntax_tests` accepts that form too.
-- `run_syntax_tests` prefers the private `sublime_api.run_syntax_test`
-  (synchronous, structured result) for files under Packages/ and
-  falls back to the "Syntax Tests" build system otherwise. The
-  fallback polls the build panel for up to `timeout` seconds.
-- The primary `run_syntax_tests` path uses `sublime_api.run_syntax_test`,
-  which is a **private, undocumented** ST API. ST has changed private
-  APIs before; if this one disappears the build-panel fallback takes
-  over automatically, but callers will see a behaviour shift (timing,
-  panel-scrape edge cases) without warning.
+- `run_syntax_tests` uses the private `sublime_api.run_syntax_test`
+  (synchronous, structured). The path must resolve under
+  `sublime.packages_path()` (directly or via a symlink in that
+  directory); paths outside the Packages tree raise.
+  `sublime_api.run_syntax_test` is **private and undocumented**; if
+  ST removes it, `run_syntax_tests` raises rather than silently
+  degrading.
 
 ## Companion skill
 
@@ -296,13 +288,6 @@ except ImportError:
 
 
 _SYNTAX_TEST_HEADER = _re.compile(r'SYNTAX TEST\s+"([^"]+)"')
-
-# ST's "Syntax Tests" build system emits a summary line of the form
-#     FAILED: 2 of 5 assertions failed
-# right before "[Finished in Xs]". The strict pattern locks onto that
-# canonical summary; the loose fallback at the build-path return site
-# catches the case where ST's format drifts.
-_FAILED_LINE_RE = _re.compile(r"^FAILED: \d+ of \d+ assertions failed$")
 
 
 def open_view(path, timeout=5.0):
@@ -533,9 +518,8 @@ def _run_syntax_tests_via_api(path):
         _wait_for_resource(resource)
         total, messages = _sublime_api.run_syntax_test(resource)
     if _is_unable_to_read(messages):
-        # Under Packages but still not indexed: don't silently fall back to
-        # the 30 s build-panel path — surface the miss as an exception so
-        # it propagates up as the top-level MCP `error`.
+        # Under Packages but still not indexed: surface the miss as an
+        # exception so it propagates up as the top-level MCP `error`.
         raise RuntimeError(
             "Sublime Text has not indexed the resource at %s: %s"
             % (resource, "\n".join(messages))
@@ -572,101 +556,25 @@ def _wait_for_resource(resource_path, timeout=1.0):
     return False
 
 
-def _run_syntax_tests_via_build(path, timeout):
-    # Fallback: trigger the "Syntax Tests" build system and scrape the
-    # output panel. Used when sublime_api is unavailable or the path
-    # isn't under Packages/. Addresses the original silent-empty-result
-    # bug: require a non-empty read before considering the poll settled,
-    # and raise a self-describing exception instead of returning "".
-    window = sublime.active_window()
-    open_view(path)
-    window.run_command(
-        "build",
-        {"build_system": "Packages/Default/Syntax Tests.sublime-build"},
-    )
-    panel = None
-    for name in ("exec", "syntax_test"):
-        panel = window.find_output_panel(name)
-        if panel is not None:
-            break
-    if panel is None:
-        for name in window.panels():
-            short = name.split(".", 1)[1] if "." in name else name
-            if "exec" in short or "syntax_test" in short:
-                panel = window.find_output_panel(short)
-                if panel is not None:
-                    break
-    if panel is None:
+def run_syntax_tests(path):
+    # No fallback for paths outside Packages/: programmatic dispatch of
+    # the "Syntax Tests" build system surfaces an empty output panel
+    # and never fires the runner, so a fallback would be dead code.
+    # Callers must symlink outside-Packages files in (see
+    # _to_resource_path).
+    if _sublime_api is None or not hasattr(_sublime_api, "run_syntax_test"):
         raise RuntimeError(
-            "Sublime Text did not surface a build output panel for the "
-            "Syntax Tests build system"
+            "sublime_api.run_syntax_test is unavailable on this Sublime "
+            "Text build; run_syntax_tests has no working fallback"
         )
-    deadline = _time.time() + timeout
-    saw_content = False
-    last = ""
-    while _time.time() < deadline:
-        text = panel.substr(sublime.Region(0, panel.size()))
-        if text:
-            saw_content = True
-            if text == last and (
-                "assertions passed" in text
-                or "FAILED" in text
-                or "[Finished" in text
-            ):
-                break
-        last = text
-        _time.sleep(0.1)
-    text = panel.substr(sublime.Region(0, panel.size()))
-    if not saw_content:
-        raise TimeoutError(
-            "Syntax Tests build system produced no output before the "
-            "timeout elapsed"
-        )
-    summary_line = ""
-    for line in reversed(text.splitlines()):
-        stripped = line.strip()
-        if "assertions" in stripped or "FAILED" in stripped:
-            summary_line = stripped
-            break
-    # Strict match against ST's canonical summary first; loose fallback
-    # only kicks in when the strict pattern matched nothing (format drift).
-    # The loose match has a known false-positive risk when a test fixture's
-    # own content contains "FAILED" — guarded against by trying strict first.
-    failures = [
-        line for line in text.splitlines()
-        if _FAILED_LINE_RE.match(line.strip())
-    ]
-    if not failures:
-        failures = [
-            line for line in text.splitlines()
-            if line.lstrip().startswith("FAILED")
-        ]
-    if failures:
-        state = "failed"
-        summary = summary_line
-    elif "assertions passed" in text:
-        state = "passed"
-        summary = summary_line
-    else:
+    result = _run_syntax_tests_via_api(path)
+    if result is None:
         raise RuntimeError(
-            "Syntax Tests build system output did not contain a parsable "
-            "assertion summary"
+            "Path %r is not under sublime.packages_path(); symlink the "
+            "containing directory into Packages/ (see SKILL.md section 4) "
+            "and pass the symlinked path or its Packages/... URI" % path
         )
-    return {"state": state, "summary": summary, "output": text, "failures": failures}
-
-
-def run_syntax_tests(path, timeout=30.0):
-    # Primary path: sublime_api.run_syntax_test(resource_path). It returns
-    # (total_assertions, [error_messages]) synchronously, bypassing the
-    # build-panel race that the original implementation hit. Requires the
-    # file to live under sublime.packages_path().
-    # Fallback: build-panel scrape for paths outside Packages/ or if the
-    # private API disappears.
-    if _sublime_api is not None and hasattr(_sublime_api, "run_syntax_test"):
-        result = _run_syntax_tests_via_api(path)
-        if result is not None:
-            return result
-    return _run_syntax_tests_via_build(path, timeout)
+    return result
 '''
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -412,8 +412,7 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
         # that doesn't exist on disk. _to_resource_path maps it to a
         # Packages/... URI, sublime_api.run_syntax_test reports "unable
         # to read file", _wait_for_resource times out without the
-        # resource appearing in the index, and the API path raises
-        # rather than silently falling through to the build-panel path.
+        # resource appearing in the index, and the API path raises.
         bogus = os.path.join(
             sublime.packages_path(), "__sublime_mcp_unindexed__", "syntax_test_nope"
         )
@@ -436,69 +435,12 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
         return json.loads(outcome["output"])
 
 
-class TestRunSyntaxTestsFallback(HelperTestBase):
-    """Fallback path kicks in for files outside `sublime.packages_path()`.
-    The critical contract: never return a silent empty result."""
-
-    def test_failed_line_regex_discriminates_canonical_from_fixture_content(self):
-        # Direct in-namespace check on the strict regex's discrimination.
-        # Catches a regex regression even in environments where the build
-        # variant doesn't surface a panel (so the end-to-end populated-
-        # output test below skips).
-        code = (
-            "import json\n"
-            "_ = json.dumps({\n"
-            "    'canonical': bool(_FAILED_LINE_RE.match("
-            "'FAILED: 2 of 5 assertions failed')),\n"
-            "    'truncated': bool(_FAILED_LINE_RE.match('FAILED:')),\n"
-            "    'fixture_content': bool(_FAILED_LINE_RE.match("
-            "'FAILED to do something')),\n"
-            "    'passed_line': bool(_FAILED_LINE_RE.match("
-            "'5 assertions passed')),\n"
-            "})\n"
-            "print(_)\n"
-        )
-        resp = yield from _call_tool_yielding(code)
-        outcome = _outcome(resp)
-        self.assertIsNone(outcome["error"], outcome.get("error"))
-        r = json.loads(outcome["output"])
-        self.assertTrue(r["canonical"])
-        self.assertFalse(r["truncated"])
-        self.assertFalse(r["fixture_content"])
-        self.assertFalse(r["passed_line"])
-
-    def test_failing_fixture_returns_populated_failures(self):
-        # End-to-end: drive the build path against a real failing fixture
-        # and verify populated `failures`. Skipped on sessions where ST's
-        # "Syntax Tests" build system doesn't surface a panel — a known
-        # #17-shaped issue where run_syntax_tests now raises. The
-        # in-namespace regex test above covers regex regressions that
-        # would otherwise slip through this skip.
-        fd, path = tempfile.mkstemp(suffix=".py")
-        os.close(fd)
-        try:
-            with open(path, "w") as f:
-                f.write(HEADER)
-                f.write("x = 1\n# ^ keyword.control.flow\n")  # fails
-            code = (
-                "import json\n"
-                "_ = run_syntax_tests(%r, timeout=10.0)\n"
-                "print(json.dumps(_))\n" % path
-            )
-            resp = yield from _call_tool_yielding(code)
-            outcome = _outcome(resp)
-            if outcome["error"] is not None:
-                self.skipTest(
-                    "build path raised; populated-output coverage "
-                    "requires the Syntax Tests build system to surface a "
-                    "panel: %s" % outcome["error"].splitlines()[-1]
-                )
-            r = json.loads(outcome["output"])
-            self.assertEqual(r["state"], "failed", r)
-            self.assertGreater(len(r["failures"]), 0, r)
-            self.assertIn("FAILED", r["failures"][0])
-        finally:
-            os.unlink(path)
+class TestRunSyntaxTestsOutsidePackages(HelperTestBase):
+    """Paths outside `sublime.packages_path()` raise loudly. Programmatic
+    dispatch of the Syntax Tests build system never fires the runner
+    (#51), so there is no working fallback — the helper raises with a
+    pointer at the symlink workaround instead of silently returning
+    empty."""
 
     def test_outside_packages_describes_cause(self):
         fd, path = tempfile.mkstemp(suffix=".txt")
@@ -506,14 +448,16 @@ class TestRunSyntaxTestsFallback(HelperTestBase):
         try:
             with open(path, "w") as f:
                 f.write("just text\n")
-            code = "_ = run_syntax_tests(%r, timeout=3.0)\n" % path
+            code = "_ = run_syntax_tests(%r)\n" % path
             resp = yield from _call_tool_yielding(code)
             outcome = _outcome(resp)
             self.assertIsNotNone(outcome["error"])
-            # All three build-path raise sites name the build system;
-            # pin against the shared substring so a regression to
-            # generic-but-wrong prose fails the test.
-            self.assertIn("Syntax Tests build system", outcome["error"])
+            # Pin against substrings the helper actually produces, so a
+            # regression to generic-but-wrong prose fails the test. The
+            # path is interpolated; "symlink" names the workaround.
+            self.assertIn(path, outcome["error"])
+            self.assertIn("symlink", outcome["error"])
+            self.assertIn("Packages/", outcome["error"])
         finally:
             os.unlink(path)
 


### PR DESCRIPTION
## Summary

`_run_syntax_tests_via_build` was dead code in non-interactive contexts. Programmatic `window.run_command("build", {"build_system": "Packages/Default/Syntax Tests.sublime-build"})` surfaces an empty `output.exec` panel and never fires the `run_syntax_tests` target — the issue body of #51 enumerates what was already ruled out (variant arg, `set_timeout` main-thread dispatch, direct `run_command("run_syntax_tests")`, `set_build_system` + bare `build`). The remaining suggestion (`run_command("exec", ...)`) does not reach the `run_syntax_tests` target — that's the `target` in the build file, not `exec`. So there is no working programmatic dispatch.

Drop the fallback. `run_syntax_tests` is now API-only; outside-Packages paths raise with the path and the symlink workaround pointed at SKILL.md section 4. Missing `sublime_api.run_syntax_test` raises rather than silently degrading. The `timeout` kwarg is gone — only the build path consumed it.

The populated-failures observable is already covered on CI by `TestRunSyntaxTestsApiPath::test_mixed_pass_fail_returns_structured_failures`, which drives a real failing fixture through the API path; this is the analog the user asked for and it runs on both runners (no skip). The two build-path tests (the regex discriminator and the universally-self-skipping `test_failing_fixture_returns_populated_failures`) are gone; the surviving outside-Packages contract test is re-pinned against the new error wording.

Closes #51. Closes #17 — its `RuntimeError` raise site (`Sublime Text did not surface a build output panel`) is gone with the helper.

## Test plan

Probed live ST 4200 stable against the new dispatcher (helpers re-execed in the plugin host, since the running plugin is the merged-main version): failing fixture under `Packages/User/_probe_51/` returned `state: "failed"`, one populated failure with `Packages/User/_probe_51/syntax_test_fail:2:3` head; outside-`Packages/` `tempfile.mkstemp()` path raised `RuntimeError` with the path, `symlink`, and `sublime.packages_path()` interpolated; `Packages/__sublime_mcp_unindexed__/...` raised the existing `has not indexed` path (unchanged). CI on both runners is the deltas-from-CI part of this plan.

## Notes for reviewers

`run_syntax_tests` signature change (drops `timeout`) is a breaking change to the documented helper. `grep` confirms no in-repo callers passed `timeout` outside the deleted tests; SKILL.md and install.md examples didn't pass it either. Per the repo's no-backwards-compat-shims style, clean break.

The private-API-missing path now raises instead of silently degrading. That is the correct behaviour after this change — the build-panel fallback it was degrading to never worked in CI anyway — but worth flagging for future ST-API churn.
