### PR TITLE
Probing helpers v1: run_on_main, wider _wait_for_resource, run_inline_syntax_test, temp_packages_link

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -127,27 +127,26 @@ Same `{state, summary, output, failures}` shape as `run_syntax_tests`, with one 
 
 `view.assign_syntax` takes a `Packages/...` resource URI, not an arbitrary filesystem path. The older `view.set_syntax_file` has the same constraint but fails silently when given a filesystem path: `view.settings().get("syntax")` echoes the assigned absolute path, ST surfaces a "file not found" popup, `view.scope_name(...)` returns `text.plain` for every position, and the Python call doesn't raise. Prefer `assign_syntax_and_wait`.
 
-To test a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), symlink it in first:
-
-```bash
-ln -s /path/to/repo/testdata/Packages/Java \
-      "$HOME/Library/Application Support/Sublime Text/Packages/Java"
-```
-
-Then pass the `Packages/...` URI to `resolve_position`:
+For a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), use `temp_packages_link` to manage a per-call symlink. The helper synthesises `Packages/__sublime_mcp_temp_<nonce>__`, waits for ST's resource indexer to surface the sentinel, and returns the synthesised package name. The caller builds URIs against it and tears down via `release_packages_link`.
 
 ```python
-r = resolve_position(
-    "/path/to/syntax_test_file", row=71, col=29,
-    syntax_path="Packages/Java/Java.sublime-syntax",
-)
-print(r["scope"], "overflow:", r["overflow"], "clamped:", r["clamped"])
-assert r["resolved_syntax"] == r["requested_syntax"], r
+name = temp_packages_link("/path/to/repo/testdata/Packages/Java/Java.sublime-syntax")
+try:
+    r = resolve_position(
+        "/path/to/syntax_test_file", row=71, col=29,
+        syntax_path="Packages/%s/Java.sublime-syntax" % name,
+    )
+    print(r["scope"], "overflow:", r["overflow"], "clamped:", r["clamped"])
+    assert r["resolved_syntax"] == r["requested_syntax"], r
+finally:
+    release_packages_link(name)
 ```
 
 The returned dict also carries `overflow` (past-EOL request wrapped into a later row), `clamped` (past-EOF, point at `view.size()`) — mutually exclusive flags that surface a quiet `text_point` behaviour; the full semantics are in `TOOL_DESCRIPTION`'s "text_point overflow" section. `requested_syntax` echoes the `syntax_path` argument and `resolved_syntax` is `view.syntax().path` — assert they match before treating `scope` as ground truth, since `view.assign_syntax` accepts any string and silently falls through to Plain Text when the URI doesn't resolve.
 
-The symlink is the workaround for `resolve_position`'s `syntax_path` parameter and for `run_syntax_tests` (paths outside the Packages tree raise — there is no fallback, see #51); beware that ST might resolve to a same-named bundled syntax if the symlink ordering is wrong — `requested_syntax != resolved_syntax` flags this. #22 will let `resolve_position` accept filesystem paths instead of `Packages/...` URIs, but the `ln -s` step itself stays load-bearing — eliminating that requires helper-managed temporary symlinks (#24). `scope_at_test` parses the URI from the file's `SYNTAX TEST` header (conventionally `Packages/...` already) and exposes the same `requested_syntax` / `resolved_syntax` pair.
+`temp_packages_link` synthesises a unique nonce-named package, so the bundled `Packages/Java` continues to load alongside it — `requested_syntax != resolved_syntax` still flags any silent fallback to a built-in. The per-syntax mode is sufficient for synthetic probes and single-grammar regression triage; cross-grammar investigations where the testdata grammar embeds another testdata grammar (e.g. C# embedding RegExp) need a whole-tree mirror that shadows the built-ins, tracked separately in §6.
+
+`scope_at_test` parses the URI from the file's `SYNTAX TEST` header (conventionally `Packages/...` already) and exposes the same `requested_syntax` / `resolved_syntax` pair without needing a symlink. `run_syntax_tests` accepts any path under `sublime.packages_path()` (directly or via symlink); pair it with `temp_packages_link` to cover paths outside the Packages tree.
 
 ### Compare a parser's output against ST
 
@@ -209,8 +208,8 @@ _Last synced with issue state: 2026-05-04._
 
 - **#7** — parameterise the test suite's hardcoded `HEADER` across syntaxes.
 - **#8** — concurrency cap on the exec daemon-thread pool.
-- **#22** — `resolve_position` `syntax_path` accepts filesystem paths (URI flexibility only — does not eliminate the `ln -s` step in §4).
-- **#24** — helper-managed temporary symlinks for repo-local syntaxes. Lands the `ln -s`-elimination half of #9's body. Once landed, the §4 workaround paragraph (and #22 / #24 entries) become removable.
+- **#22** — `resolve_position` `syntax_path` accepts filesystem paths directly (URI flexibility on top of `temp_packages_link`).
+- **whole-tree mirror** (follow-up to #24) — `temp_packages_link` covers per-syntax probing, but cross-grammar investigations where one testdata grammar embeds another (e.g. C# embedding RegExp) need the testdata tree to *shadow* ST's built-ins, not coexist with them. Different lifecycle (parent symlink, per-entry shadowing); not yet implemented.
 - **#10** — documented per-call latency for bulk probes + daemon-thread / cold-tokenisation clarification.
 - **#34** — `find_resources` lists `Packages/...` paths whose `load_resource` raises `FileNotFoundError` (cache-survives-source case observed against `Packages/C#/Embeddings/Regex (for C#).sublime-syntax`); characterise before deciding doc vs code fix.
 
@@ -224,6 +223,7 @@ _Last synced with issue state: 2026-05-04._
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.
 - `run_on_main(callable, timeout=2.0)` — schedule `callable` on ST's main thread; return its value (or re-raise its exception). Required wrapper for `view.run_command(...)` and other `TextCommand` mutations.
+- `temp_packages_link(filesystem_path) -> str` / `release_packages_link(name) -> None` — synthesise / tear down a per-call `Packages/__sublime_mcp_temp_<nonce>__` symlink for repo-local syntaxes. Returns the synthesised package name; build URIs as `Packages/<name>/<basename>`.
 - `find_resources(pattern) -> list[str]` — wrap `sublime.find_resources`.
 - `reload_syntax(resource_path) -> None` — force-reload a `.sublime-syntax` resource via view reactivation.
 

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -107,6 +107,22 @@ Branch on `state` for the assertion-run outcome:
 
 When ST cannot complete the run, `run_syntax_tests` raises `RuntimeError` and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. The reachable causes are: resource not yet indexed, path outside `sublime.packages_path()` (symlink it in first — see "Confirm which syntax ST assigned (and handle repo-local syntaxes)" below), and the private `sublime_api.run_syntax_test` missing on this ST build. For ground-truth questions that don't need the assertion runner, fall back to `scope_at` / `scope_at_test` or `resolve_position`.
 
+### Probe a synthetic case inline
+
+For "what does ST do on this case?" probes, `run_inline_syntax_test(content, name)` owns the file-write, indexing wait, runner call, and cleanup. The header inside `content` selects the syntax under test; the syntax must already be reachable to ST (bundled or via `temp_packages_link`).
+
+```python
+r = run_inline_syntax_test(
+    '# SYNTAX TEST "Packages/Python/Python.sublime-syntax"\n'
+    'x = 1\n'
+    '# ^ source.python\n',
+    "syntax_test_probe",
+)
+print(r["state"], r["summary"])
+```
+
+Same `{state, summary, output, failures}` shape as `run_syntax_tests`, with one extra state `"inconclusive"` when ST never indexes the temp resource within the wait budget. The probe's temp dir is removed on every code path (within-call `try/finally`); a cross-call sweep at the start of each call cleans up SIGKILL-orphaned dirs older than 60 s.
+
 ### Confirm which syntax ST assigned (and handle repo-local syntaxes)
 
 `view.assign_syntax` takes a `Packages/...` resource URI, not an arbitrary filesystem path. The older `view.set_syntax_file` has the same constraint but fails silently when given a filesystem path: `view.settings().get("syntax")` echoes the assigned absolute path, ST surfaces a "file not found" popup, `view.scope_name(...)` returns `text.plain` for every position, and the Python call doesn't raise. Prefer `assign_syntax_and_wait`.
@@ -196,7 +212,6 @@ _Last synced with issue state: 2026-05-04._
 - **#22** — `resolve_position` `syntax_path` accepts filesystem paths (URI flexibility only — does not eliminate the `ln -s` step in §4).
 - **#24** — helper-managed temporary symlinks for repo-local syntaxes. Lands the `ln -s`-elimination half of #9's body. Once landed, the §4 workaround paragraph (and #22 / #24 entries) become removable.
 - **#10** — documented per-call latency for bulk probes + daemon-thread / cold-tokenisation clarification.
-- **#30** — `run_inline_syntax_test(content, name)` lifecycle helper. Collapses the write-to-`Packages/User/`-then-poll-then-cleanup dance into one call; pairs with #24 on the on-disk side.
 - **#34** — `find_resources` lists `Packages/...` paths whose `load_resource` raises `FileNotFoundError` (cache-survives-source case observed against `Packages/C#/Embeddings/Regex (for C#).sublime-syntax`); characterise before deciding doc vs code fix.
 
 ## 7. Reference — preloaded helpers
@@ -205,6 +220,7 @@ _Last synced with issue state: 2026-05-04._
 - `scope_at_test(path, row, col) -> dict` — parse `# SYNTAX TEST` header, assign that syntax, return `{"scope", "requested_syntax", "resolved_syntax"}`. `requested_syntax != resolved_syntax` flags silent fallback to the wrong syntax.
 - `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags; also carries `requested_syntax` / `resolved_syntax`.
 - `run_syntax_tests(path) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`. Path must resolve under `sublime.packages_path()` (directly or via a symlink in that directory); paths outside the Packages tree raise.
+- `run_inline_syntax_test(content, name) -> dict` — synthetic-probe variant: writes `content` to a managed temp dir under `Packages/User/`, runs the runner, cleans up. Same shape as `run_syntax_tests` plus a `"inconclusive"` state when ST never indexes the temp resource.
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.
 - `run_on_main(callable, timeout=2.0)` — schedule `callable` on ST's main thread; return its value (or re-raise its exception). Required wrapper for `view.run_command(...)` and other `TextCommand` mutations.

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -156,6 +156,19 @@ print(r["summary"])
 
 If step 3 passes, the downstream parser diverges from ST — file the bug against the parser. If step 3 fails too, the test data itself has the issue; fix the data, not the parser.
 
+### Mutate a buffer from a snippet
+
+Snippets exec on a worker thread; `view.run_command(...)` requires ST's main thread and silently no-ops if called directly. Wrap the call in `run_on_main` — it owns the `set_timeout` schedule, the completion signal, and the timeout error path.
+
+```python
+v = sublime.active_window().new_file()
+run_on_main(lambda: v.run_command("append", {"characters": "hello"}))
+print(v.size())  # 5
+v.set_scratch(True); v.close()
+```
+
+`run_on_main(callable, timeout=2.0)` returns the callable's value; exceptions raised inside the callable propagate to the worker thread (and surface as the snippet's `error`).
+
 ### Bulk probes
 
 `scope_name` on an already-tokenised view is thread-safe and runs concurrent with ST's UI, so a several-hundred-row sweep in one `exec_sublime_python` call comfortably fits the 60 s per-call budget. The cold-view cost is a one-time tokenisation pass on the first helper call against a given path.
@@ -176,7 +189,7 @@ Measured per-call latency is tracked in #10.
 
 ## 6. Known limitations / tracking
 
-_Last synced with issue state: 2026-05-03._
+_Last synced with issue state: 2026-05-04._
 
 - **#6** — bump `_wait_for_resource` timeout 1s → 2-3s for cold-disk indexing.
 - **#7** — parameterise the test suite's hardcoded `HEADER` across syntaxes.
@@ -185,7 +198,6 @@ _Last synced with issue state: 2026-05-03._
 - **#24** — helper-managed temporary symlinks for repo-local syntaxes. Lands the `ln -s`-elimination half of #9's body. Once landed, the §4 workaround paragraph (and #22 / #24 entries) become removable.
 - **#10** — documented per-call latency for bulk probes + daemon-thread / cold-tokenisation clarification.
 - **#30** — `run_inline_syntax_test(content, name)` lifecycle helper. Collapses the write-to-`Packages/User/`-then-poll-then-cleanup dance into one call; pairs with #24 on the on-disk side.
-- **#33** — daemon-thread `view.run_command(...)` is a silent no-op without `set_timeout`. Until the doc gotcha or `run_on_main` helper lands, callers mutating buffers from snippet code need to schedule via `set_timeout` and gate on a `threading.Event`.
 - **#34** — `find_resources` lists `Packages/...` paths whose `load_resource` raises `FileNotFoundError` (cache-survives-source case observed against `Packages/C#/Embeddings/Regex (for C#).sublime-syntax`); characterise before deciding doc vs code fix.
 
 ## 7. Reference — preloaded helpers
@@ -196,6 +208,7 @@ _Last synced with issue state: 2026-05-03._
 - `run_syntax_tests(path) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`. Path must resolve under `sublime.packages_path()` (directly or via a symlink in that directory); paths outside the Packages tree raise.
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.
+- `run_on_main(callable, timeout=2.0)` — schedule `callable` on ST's main thread; return its value (or re-raise its exception). Required wrapper for `view.run_command(...)` and other `TextCommand` mutations.
 - `find_resources(pattern) -> list[str]` — wrap `sublime.find_resources`.
 - `reload_syntax(resource_path) -> None` — force-reload a `.sublime-syntax` resource via view reactivation.
 

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -191,7 +191,6 @@ Measured per-call latency is tracked in #10.
 
 _Last synced with issue state: 2026-05-04._
 
-- **#6** — bump `_wait_for_resource` timeout 1s → 2-3s for cold-disk indexing.
 - **#7** — parameterise the test suite's hardcoded `HEADER` across syntaxes.
 - **#8** — concurrency cap on the exec daemon-thread pool.
 - **#22** — `resolve_position` `syntax_path` accepts filesystem paths (URI flexibility only — does not eliminate the `ln -s` step in §4).

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -43,9 +43,8 @@ capture its output.
 The snippet runs on a dedicated daemon thread so it can wait on file
 loads and build panels without deadlocking ST's UI. Most of the ST
 API is thread-safe from any thread; for the few operations that
-require the main UI thread (e.g. `TextCommand` edit tokens), use
-`sublime.set_timeout(lambda: ..., 0)` inside the snippet and poll.
-The following names are preloaded:
+require the main UI thread (e.g. `TextCommand` edit tokens), wrap
+them in `run_on_main(...)`. The following names are preloaded:
 
 - `sublime`, `sublime_plugin` — the ST Python API modules.
 - `scope_at(path, row, col) -> dict` — opens the file, returns
@@ -101,6 +100,11 @@ The following names are preloaded:
   deterministic; stage 2 (tokenisation) is best-effort — ST has no
   public tokenisation-complete signal. For large files, re-read
   `scope_name` after use rather than trusting the helper.
+- `run_on_main(callable, timeout=2.0)` — schedules `callable` on
+  ST's main thread, waits for it to finish, returns its value (or
+  re-raises whatever it raised). Use it for buffer-mutating
+  `TextCommand` calls (`view.run_command("append", ...)` and friends)
+  which silently no-op when invoked from the worker thread.
 
 ## text_point overflow
 
@@ -248,15 +252,29 @@ v = w.active_view()
 print(v.file_name(), v.sel()[0], v.scope_name(v.sel()[0].a))
 ```
 
+### Mutate a buffer from a snippet
+
+`view.run_command(...)` requires ST's main thread. Wrap it in
+`run_on_main` — direct calls from the worker thread silently no-op.
+
+```python
+v = sublime.active_window().new_file()
+run_on_main(lambda: v.run_command("append", {"characters": "hello"}))
+print(v.size())  # 5
+v.set_scratch(True)
+v.close()
+```
+
 ## Gotchas
 
 - Hard timeout per call is 60 s.
 - The snippet runs on a dedicated daemon thread (not ST's async
   worker and not the main UI thread). Most of the ST API is
   thread-safe, but a few mutating operations (`TextCommand` edit
-  tokens) require the main thread — call
-  `sublime.set_timeout(lambda: ..., 0)` from within the snippet if
-  you need that, and poll for completion.
+  tokens) require the main thread. Use `run_on_main(callable)` —
+  it owns the `set_timeout` schedule, the completion signal, and
+  the timeout error path. Direct calls to `view.run_command(...)`
+  from the worker thread silently no-op.
 - File paths must be absolute for `scope_at` / `scope_at_test` /
   `resolve_position` / `run_syntax_tests` / `open_view`.
   `find_resources` uses ST's `Packages/...` virtual paths, and
@@ -437,6 +455,34 @@ def reload_syntax(resource_path):
 
 def find_resources(pattern):
     return list(sublime.find_resources(pattern))
+
+
+def run_on_main(callable_, timeout=2.0):
+    # Snippets exec on a worker thread. ST's TextCommand edit tokens
+    # (and a handful of other mutating operations) silently no-op when
+    # called off the main thread — view.run_command(...) returns
+    # cleanly, view.size() reports zero. Schedule on the main thread
+    # via set_timeout, signal completion through threading.Event, then
+    # propagate the return value or re-raise the exception on the
+    # worker thread so traceback capture in _exec_on_worker sees it.
+    import threading as _threading
+    done = _threading.Event()
+    box = {}
+    def runner():
+        try:
+            box["result"] = callable_()
+        except BaseException as exc:
+            box["exc"] = exc
+        finally:
+            done.set()
+    sublime.set_timeout(runner, 0)
+    if not done.wait(timeout):
+        raise TimeoutError(
+            "run_on_main: callable did not complete within %ss" % timeout
+        )
+    if "exc" in box:
+        raise box["exc"]
+    return box.get("result")
 
 
 def _to_resource_path(path):

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -115,6 +115,17 @@ them in `run_on_main(...)`. The following names are preloaded:
   re-raises whatever it raised). Use it for buffer-mutating
   `TextCommand` calls (`view.run_command("append", ...)` and friends)
   which silently no-op when invoked from the worker thread.
+- `temp_packages_link(filesystem_path) -> str` /
+  `release_packages_link(name) -> None` — synthesise (and tear down)
+  a managed `Packages/__sublime_mcp_temp_<nonce>__` symlink whose
+  target is `filesystem_path`'s parent (or the path itself if a
+  directory). Returns the synthesised package name; build URIs as
+  `Packages/<name>/<basename>` to feed `assign_syntax_and_wait` /
+  `resolve_position`. Replaces the manual `ln -s ...` recipe for
+  repo-local syntaxes (e.g. `testdata/Packages/...` from another
+  parser's repo). For cross-grammar investigations needing the
+  whole testdata tree (cross-includes resolve to built-ins under
+  this per-syntax mode), see SKILL.md §6 follow-up.
 
 ## text_point overflow
 
@@ -217,6 +228,21 @@ r = run_inline_syntax_test(
     "syntax_test_probe",
 )
 print(r["state"], r["summary"])
+```
+
+### Probe a repo-local syntax
+
+```python
+name = temp_packages_link("/abs/path/to/repo/testdata/Packages/Java/Java.sublime-syntax")
+try:
+    r = resolve_position(
+        "/abs/path/to/syntax_test_input", row=0, col=0,
+        syntax_path="Packages/%s/Java.sublime-syntax" % name,
+    )
+    assert r["resolved_syntax"] == r["requested_syntax"], r
+    print(r["scope"])
+finally:
+    release_packages_link(name)
 ```
 
 ### Compare a syntect baseline failure against ST
@@ -678,6 +704,94 @@ def _new_temp_dir():
     full = _os.path.join(sublime.packages_path(), "User", name)
     _os.makedirs(full)
     return name, full
+
+
+def _sweep_stale_temp_packages():
+    # Sister to _sweep_stale_temp_dirs but for symlinks under
+    # Packages/ (not Packages/User/). Uses lstat so the mtime is the
+    # symlink's, not the target's; a stale symlink whose target was
+    # rewritten yesterday should still be eligible for sweep.
+    packages_root = sublime.packages_path()
+    try:
+        entries = _os.listdir(packages_root)
+    except OSError:
+        return
+    now = _time.time()
+    for name in entries:
+        if not (name.startswith(_TEMP_DIR_PREFIX) and name.endswith(_TEMP_DIR_SUFFIX)):
+            continue
+        full = _os.path.join(packages_root, name)
+        if not _os.path.islink(full):
+            continue
+        try:
+            age = now - _os.lstat(full).st_mtime
+        except OSError:
+            continue
+        if age < _TEMP_DIR_MAX_AGE_SECONDS:
+            continue
+        try:
+            _os.unlink(full)
+        except OSError:
+            pass
+
+
+def temp_packages_link(filesystem_path):
+    # Synthesise a Packages/__sublime_mcp_temp_<nonce>__ symlink whose
+    # target is the parent dir of `filesystem_path` (or the path itself
+    # if it's a directory). Wait for ST's resource indexer to surface
+    # the sentinel resource. Returns the synthesised package name —
+    # callers build "Packages/<name>/<basename>" URIs against the
+    # existing helpers (assign_syntax_and_wait, resolve_position) and
+    # call release_packages_link(name) when done. Two-layer cleanup
+    # (mirrors run_inline_syntax_test): caller-managed within-call,
+    # _sweep_stale_temp_packages at the head for SIGKILL paths.
+    import uuid as _uuid
+    abs_path = _os.path.abspath(filesystem_path)
+    if _os.path.isdir(abs_path):
+        target_dir = abs_path
+        sentinel_basename = None
+    else:
+        target_dir = _os.path.dirname(abs_path)
+        sentinel_basename = _os.path.basename(abs_path)
+    if not _os.path.isdir(target_dir):
+        raise RuntimeError(
+            "temp_packages_link: target dir %r does not exist" % target_dir
+        )
+    _sweep_stale_temp_packages()
+    nonce = _uuid.uuid4().hex[:12]
+    name = "%s%s%s" % (_TEMP_DIR_PREFIX, nonce, _TEMP_DIR_SUFFIX)
+    link_path = _os.path.join(sublime.packages_path(), name)
+    _os.symlink(target_dir, link_path)
+    if sentinel_basename is not None:
+        sentinel_resource = "Packages/%s/%s" % (name, sentinel_basename)
+        if not _wait_for_resource(sentinel_resource):
+            try:
+                _os.unlink(link_path)
+            finally:
+                raise RuntimeError(
+                    "temp_packages_link: ST did not index %s within the wait budget"
+                    % sentinel_resource
+                )
+    return name
+
+
+def release_packages_link(name):
+    # Companion teardown for temp_packages_link. Idempotent: a missing
+    # link is not an error (the cross-call sweep may have removed it).
+    # Refuses to touch any name outside the temp prefix/suffix scheme,
+    # so a buggy caller can't accidentally unlink a real package.
+    if not (name.startswith(_TEMP_DIR_PREFIX) and name.endswith(_TEMP_DIR_SUFFIX)):
+        raise ValueError(
+            "release_packages_link: refusing to remove non-temp name %r" % name
+        )
+    link_path = _os.path.join(sublime.packages_path(), name)
+    if not _os.path.lexists(link_path):
+        return
+    if not _os.path.islink(link_path):
+        raise RuntimeError(
+            "release_packages_link: %r is not a symlink; refusing to remove" % link_path
+        )
+    _os.unlink(link_path)
 
 
 def run_inline_syntax_test(content, name):

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -589,15 +589,31 @@ def _is_unable_to_read(messages):
     return any("unable to read file" in m for m in messages)
 
 
-def _wait_for_resource(resource_path, timeout=1.0):
-    # ST's resource index can lag behind the filesystem by a few hundred
-    # ms on newly-created files; poll find_resources until the resource
-    # becomes visible.
+def _wait_for_resource(resource_path, timeout=3.0):
+    # ST's resource index can lag behind the filesystem by seconds, not
+    # milliseconds, on cold-disk or post-write indexing — one observed
+    # cold-register latency was 15 s for a freshly-written
+    # .sublime-syntax (#6). Default budget bumped from 1.0 s to 3.0 s
+    # to cover the realistic upper bound of common cases without
+    # waiting forever on genuine misses.
+    # Past two-thirds of the budget without resolution, fire one
+    # `refresh_folder_list` to nudge ST's indexer; idempotent and
+    # bounded by the same total budget. Dispatched through set_timeout
+    # because run_command is application-level and the safe default
+    # off the worker thread is main-thread scheduling.
     basename = resource_path.rsplit("/", 1)[-1]
-    deadline = _time.time() + timeout
+    start = _time.time()
+    deadline = start + timeout
+    refresh_threshold = start + (timeout * 2.0 / 3.0)
+    refreshed = False
     while _time.time() < deadline:
         if resource_path in sublime.find_resources(basename):
             return True
+        if not refreshed and _time.time() >= refresh_threshold:
+            sublime.set_timeout(
+                lambda: sublime.run_command("refresh_folder_list"), 0
+            )
+            refreshed = True
         _time.sleep(0.02)
     return False
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -87,6 +87,16 @@ them in `run_on_main(...)`. The following names are preloaded:
   MCP response — the same channel any other helper failure uses.
   Files outside Packages/ must be symlinked in (the helper walks
   symlinks); see SKILL.md section 4.
+- `run_inline_syntax_test(content, name) -> dict` — for synthetic
+  probes ("what does ST do on this case?"). Writes `content` to a
+  per-call temp dir under `Packages/User/`, runs ST's syntax-test
+  runner, cleans up. Same `{state, summary, output, failures}`
+  contract as `run_syntax_tests`, plus a third state
+  `"inconclusive"` when ST never indexes the temp resource within
+  the wait budget (looser than `run_syntax_tests`, which raises —
+  fresh-resource probes hit indexing latency too often for raise to
+  be the right default). The header inside `content` chooses the
+  syntax under test; the syntax must already be reachable.
 - `reload_syntax(resource_path) -> None` — force-reloads a
   `.sublime-syntax` resource. Useful when ST cached an older version
   (e.g. after an external edit via symlink).
@@ -195,6 +205,18 @@ r = run_syntax_tests("/path/to/Packages/C#/tests/syntax_test_Generics.cs")
 print(r["summary"])
 for msg in r["failures"]:
     print(msg)
+```
+
+### Probe a synthetic case inline
+
+```python
+r = run_inline_syntax_test(
+    '# SYNTAX TEST "Packages/Python/Python.sublime-syntax"\n'
+    'x = 1\n'
+    '# ^ source.python\n',
+    "syntax_test_probe",
+)
+print(r["state"], r["summary"])
 ```
 
 ### Compare a syntect baseline failure against ST
@@ -616,6 +638,107 @@ def _wait_for_resource(resource_path, timeout=3.0):
             refreshed = True
         _time.sleep(0.02)
     return False
+
+
+_TEMP_DIR_PREFIX = "__sublime_mcp_temp_"
+_TEMP_DIR_SUFFIX = "__"
+_TEMP_DIR_MAX_AGE_SECONDS = 60.0
+
+
+def _sweep_stale_temp_dirs():
+    # Cross-call defensive cleanup for run_inline_syntax_test:
+    # SIGKILL / OS panic bypass the within-call try/finally. List
+    # Packages/User entries matching the nonce scheme; remove ones
+    # older than the max-age threshold so a concurrent in-flight call
+    # isn't clobbered.
+    user_dir = _os.path.join(sublime.packages_path(), "User")
+    try:
+        entries = _os.listdir(user_dir)
+    except OSError:
+        return
+    now = _time.time()
+    for name in entries:
+        if not (name.startswith(_TEMP_DIR_PREFIX) and name.endswith(_TEMP_DIR_SUFFIX)):
+            continue
+        full = _os.path.join(user_dir, name)
+        try:
+            age = now - _os.path.getmtime(full)
+        except OSError:
+            continue
+        if age < _TEMP_DIR_MAX_AGE_SECONDS:
+            continue
+        import shutil as _shutil
+        _shutil.rmtree(full, ignore_errors=True)
+
+
+def _new_temp_dir():
+    import uuid as _uuid
+    nonce = _uuid.uuid4().hex[:12]
+    name = "%s%s%s" % (_TEMP_DIR_PREFIX, nonce, _TEMP_DIR_SUFFIX)
+    full = _os.path.join(sublime.packages_path(), "User", name)
+    _os.makedirs(full)
+    return name, full
+
+
+def run_inline_syntax_test(content, name):
+    # Write `content` to Packages/User/<nonce>/<name>, run ST's syntax-
+    # test runner against it, return the same {state, summary, output,
+    # failures} shape as run_syntax_tests. The header inside `content`
+    # (e.g. `# SYNTAX TEST "Packages/Python/Python.sublime-syntax"`)
+    # determines which syntax is exercised; the syntax must already be
+    # reachable to ST (bundled or via temp_packages_link).
+    # Two-layer cleanup: within-call try/finally for Python-visible
+    # failures, _sweep_stale_temp_dirs at the head for SIGKILL paths.
+    # Returns state="inconclusive" rather than raising on indexing
+    # miss — fresh-resource probes hit indexing latency commonly
+    # enough that a looser contract beats burning the snippet.
+    if _sublime_api is None or not hasattr(_sublime_api, "run_syntax_test"):
+        raise RuntimeError(
+            "sublime_api.run_syntax_test is unavailable on this Sublime "
+            "Text build; run_inline_syntax_test has no working fallback"
+        )
+    _sweep_stale_temp_dirs()
+    nonce_name, temp_dir = _new_temp_dir()
+    try:
+        file_path = _os.path.join(temp_dir, name)
+        with open(file_path, "w") as f:
+            f.write(content)
+        resource = "Packages/User/%s/%s" % (nonce_name, name)
+        if not _wait_for_resource(resource):
+            return {
+                "state": "inconclusive",
+                "summary": "Sublime Text has not indexed the resource at %s" % resource,
+                "output": "",
+                "failures": [],
+            }
+        total, messages = _sublime_api.run_syntax_test(resource)
+        if _is_unable_to_read(messages):
+            _wait_for_resource(resource)
+            total, messages = _sublime_api.run_syntax_test(resource)
+        if _is_unable_to_read(messages):
+            return {
+                "state": "inconclusive",
+                "summary": "Sublime Text could not read %s after indexing wait" % resource,
+                "output": "",
+                "failures": [],
+            }
+        failures = list(messages)
+        if failures:
+            return {
+                "state": "failed",
+                "summary": "FAILED: %d of %d assertions failed" % (len(failures), total),
+                "output": "\n".join(failures),
+                "failures": failures,
+            }
+        return {
+            "state": "passed",
+            "summary": "%d assertions passed" % total,
+            "output": "%d assertions passed" % total,
+            "failures": [],
+        }
+    finally:
+        import shutil as _shutil
+        _shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 def run_syntax_tests(path):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -811,3 +811,119 @@ class TestWaitForResource(HelperTestBase):
         self.assertIn("refresh_folder_list", lines[1])
         # Make sure it fired exactly once, not on every poll iteration.
         self.assertEqual(lines[1].count("refresh_folder_list"), 1)
+
+
+class TestRunInlineSyntaxTest(HelperTestBase):
+    """`run_inline_syntax_test` writes a probe file under
+    `Packages/User/__sublime_mcp_temp_<nonce>__/`, runs ST's syntax-
+    test runner, and cleans up. Mirrors `TestRunSyntaxTestsApiPath` but
+    on the inline-probe path (#30).
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        if not cls.api_path_available:
+            raise unittest.SkipTest(
+                "sublime_api.run_syntax_test unavailable on this platform"
+            )
+
+    @classmethod
+    def _temp_dir_count(cls):
+        # Count Packages/User/__sublime_mcp_temp_*__ entries — the
+        # helper's nonce scheme. Used to assert cleanup on success and
+        # failure paths.
+        user_dir = os.path.join(sublime.packages_path(), "User")
+        try:
+            entries = os.listdir(user_dir)
+        except OSError:
+            return 0
+        return sum(
+            1
+            for e in entries
+            if e.startswith("__sublime_mcp_temp_") and e.endswith("__")
+        )
+
+    def test_passes_returns_passed_state(self):
+        before = self._temp_dir_count()
+        code = (
+            "import json\n"
+            "_ = run_inline_syntax_test(\n"
+            "    '# SYNTAX TEST \"Packages/Python/Python.sublime-syntax\"\\n'\n"
+            "    'x = 1\\n'\n"
+            "    '# ^ source.python\\n',\n"
+            "    'syntax_test_pass',\n"
+            ")\n"
+            "print(json.dumps(_))\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        r = json.loads(outcome["output"])
+        self.assertEqual(r["state"], "passed", r)
+        self.assertEqual(r["failures"], [])
+        self.assertEqual(self._temp_dir_count(), before)
+
+    def test_failing_assertion_populates_failures(self):
+        before = self._temp_dir_count()
+        code = (
+            "import json\n"
+            "_ = run_inline_syntax_test(\n"
+            "    '# SYNTAX TEST \"Packages/Python/Python.sublime-syntax\"\\n'\n"
+            "    'x = 1\\n'\n"
+            "    '# ^ keyword.control.flow\\n',\n"
+            "    'syntax_test_fail',\n"
+            ")\n"
+            "print(json.dumps(_))\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        r = json.loads(outcome["output"])
+        self.assertEqual(r["state"], "failed", r)
+        self.assertEqual(len(r["failures"]), 1, r)
+        self.assertIn("scope does not match", r["failures"][0])
+        self.assertEqual(self._temp_dir_count(), before)
+
+    def test_temp_dir_cleaned_up_on_failure(self):
+        # Force the helper to raise mid-flight by passing a non-string
+        # `name` so the os.path.join inside the try block blows up. The
+        # finally must still rmtree the temp dir.
+        before = self._temp_dir_count()
+        code = (
+            "try:\n"
+            "    run_inline_syntax_test('whatever', None)\n"
+            "except Exception:\n"
+            "    pass\n"
+            "print('done')\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(self._temp_dir_count(), before)
+
+    def test_stale_dir_swept_on_next_call(self):
+        # Plant a stale temp dir with mtime 90 s in the past, then run
+        # a successful inline test; the sweep at the head of the call
+        # should remove the planted dir.
+        user_dir = os.path.join(sublime.packages_path(), "User")
+        stale = os.path.join(user_dir, "__sublime_mcp_temp_stale123__")
+        os.makedirs(stale, exist_ok=True)
+        self.addCleanup(shutil.rmtree, stale, ignore_errors=True)
+        old = time.time() - 90.0
+        os.utime(stale, (old, old))
+        self.assertTrue(os.path.isdir(stale))
+        code = (
+            "_ = run_inline_syntax_test(\n"
+            "    '# SYNTAX TEST \"Packages/Python/Python.sublime-syntax\"\\n'\n"
+            "    'x = 1\\n'\n"
+            "    '# ^ source.python\\n',\n"
+            "    'syntax_test_sweep',\n"
+            ")\n"
+            "print(_['state'])\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "passed")
+        self.assertFalse(os.path.exists(stale))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -709,3 +709,57 @@ class TestToResourcePathSymlinked(HelperTestBase):
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
         self.assertEqual(outcome["output"].strip(), "None")
+
+
+class TestRunOnMain(HelperTestBase):
+    """`run_on_main` schedules a callable on ST's main thread and round-
+    trips its return value or raised exception back to the worker. The
+    load-bearing case is buffer mutation via `view.run_command(...)`,
+    which silently no-ops when called directly from the worker thread.
+    """
+
+    def test_returns_callable_result(self):
+        code = "_ = run_on_main(lambda: 42)\n"
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["result"], "42")
+
+    def test_propagates_exception(self):
+        code = "_ = run_on_main(lambda: 1 / 0)\n"
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("ZeroDivisionError", outcome["error"])
+
+    def test_timeout_raises(self):
+        # 0.1 s budget; callable sleeps 1 s. The run_on_main TimeoutError
+        # propagates as the snippet's `error`.
+        code = (
+            "import time\n"
+            "_ = run_on_main(lambda: time.sleep(1.0), timeout=0.1)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("TimeoutError", outcome["error"])
+        self.assertIn("run_on_main", outcome["error"])
+        self.assertIn("0.1", outcome["error"])
+
+    def test_view_run_command_actually_mutates(self):
+        # The original failure mode: view.run_command on the worker
+        # thread is a silent no-op. With run_on_main the buffer should
+        # actually grow.
+        code = (
+            "v = sublime.active_window().new_file()\n"
+            "try:\n"
+            "    run_on_main(lambda: v.run_command('append', {'characters': 'hello'}))\n"
+            "    print(v.size())\n"
+            "finally:\n"
+            "    v.set_scratch(True)\n"
+            "    v.close()\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "5")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -763,3 +763,51 @@ class TestRunOnMain(HelperTestBase):
         outcome = _outcome(resp)
         self.assertIsNone(outcome["error"], outcome.get("error"))
         self.assertEqual(outcome["output"].strip(), "5")
+
+
+class TestWaitForResource(HelperTestBase):
+    """`_wait_for_resource` widened from 1.0 s to 3.0 s and gained a
+    one-shot `refresh_folder_list` nudge past two-thirds of the budget
+    (#6). The signature default is the externally-visible contract;
+    the refresh is the structural change.
+    """
+
+    def test_default_timeout_is_three_seconds(self):
+        # The default reaches every transitive caller — _run_syntax_tests_via_api
+        # at sublime_mcp.py:518 inherits it without naming it, so the
+        # signature itself is the right anchor.
+        code = (
+            "import inspect\n"
+            "_ = inspect.signature(_wait_for_resource).parameters['timeout'].default\n"
+            "print(_)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "3.0")
+
+    def test_refresh_folder_list_fires_after_two_thirds(self):
+        # Patch sublime.run_command so the test doesn't actually nudge
+        # ST's indexer. 0.3 s budget → refresh at ~0.2 s → ~0.1 s of
+        # post-refresh polling before the deadline. The set_timeout
+        # dispatch is async; sleep within the patch context after the
+        # wait returns so the lambda has time to land on main.
+        code = (
+            "import time\n"
+            "import unittest.mock\n"
+            "calls = []\n"
+            "with unittest.mock.patch.object(sublime, 'run_command', new=lambda *a, **k: calls.append(a)):\n"
+            "    found = _wait_for_resource('Packages/__sublime_mcp_nonexistent__/x.bar', timeout=0.3)\n"
+            "    time.sleep(0.3)\n"
+            "print(found)\n"
+            "print(calls)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        lines = outcome["output"].strip().splitlines()
+        self.assertEqual(lines[0], "False")
+        # Single call to run_command with positional arg "refresh_folder_list".
+        self.assertIn("refresh_folder_list", lines[1])
+        # Make sure it fired exactly once, not on every poll iteration.
+        self.assertEqual(lines[1].count("refresh_folder_list"), 1)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -927,3 +927,166 @@ class TestRunInlineSyntaxTest(HelperTestBase):
         self.assertIsNone(outcome["error"], outcome.get("error"))
         self.assertEqual(outcome["output"].strip(), "passed")
         self.assertFalse(os.path.exists(stale))
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "TestTempPackagesLink requires symlink creation, which needs "
+    "SeCreateSymbolicLinkPrivilege or Developer Mode on Windows. "
+    "Same rationale as TestToResourcePathSymlinked.",
+)
+class TestTempPackagesLink(HelperTestBase):
+    """`temp_packages_link` synthesises a managed
+    `Packages/__sublime_mcp_temp_<nonce>__` symlink whose target is a
+    repo-local syntax dir, waits for ST to index the sentinel, returns
+    the synthesised package name. `release_packages_link` tears it
+    down with prefix/suffix validation. Mirrors
+    `TestToResourcePathSymlinked` blast-radius and cleanup discipline.
+    """
+
+    SYNTAX_CONTENT = (
+        "%YAML 1.2\n"
+        "---\n"
+        "name: SublimeMcpTempLinkProbe\n"
+        "scope: source.smtlp\n"
+        "file_extensions: [smtlp]\n"
+        "version: 2\n"
+        "contexts:\n"
+        "  main:\n"
+        "    - match: 'x'\n"
+        "      scope: keyword.smtlp\n"
+    )
+
+    def setUp(self):
+        # Each test gets its own target dir + syntax file. addCleanup
+        # ensures teardown even on partial failure. Defensive sweep at
+        # the start of every test removes any nonce-named link the
+        # helper might have left behind from a prior crash.
+        self._defensive_link_sweep()
+        self.target_dir = tempfile.mkdtemp(prefix="sublime_mcp_test_link_")
+        self.addCleanup(shutil.rmtree, self.target_dir, ignore_errors=True)
+        self.syntax_basename = "Probe.sublime-syntax"
+        self.syntax_path = os.path.join(self.target_dir, self.syntax_basename)
+        with open(self.syntax_path, "w") as f:
+            f.write(self.SYNTAX_CONTENT)
+
+    def _defensive_link_sweep(self):
+        # Same shape as TestToResourcePathSymlinked.setUp's defensive
+        # unlink, scaled to the temp-prefix scheme: any leftover
+        # nonce-named symlink gets removed regardless of age.
+        packages_root = sublime.packages_path()
+        for name in os.listdir(packages_root):
+            if not (name.startswith("__sublime_mcp_temp_") and name.endswith("__")):
+                continue
+            full = os.path.join(packages_root, name)
+            if os.path.islink(full):
+                try:
+                    os.unlink(full)
+                except OSError:
+                    pass
+
+    def _release(self, name):
+        # Cleanup helper for tests that successfully create a link.
+        # Goes through the MCP boundary so we exercise the public
+        # surface, but tolerates a missing link in case the test
+        # already cleaned up.
+        link_path = os.path.join(sublime.packages_path(), name)
+        if os.path.lexists(link_path) and os.path.islink(link_path):
+            os.unlink(link_path)
+
+    def test_creates_link_with_temp_prefix(self):
+        code = (
+            "_ = temp_packages_link(%r)\n"
+            "print(_)\n"
+        ) % self.syntax_path
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        name = outcome["output"].strip()
+        self.addCleanup(self._release, name)
+        self.assertTrue(name.startswith("__sublime_mcp_temp_"))
+        self.assertTrue(name.endswith("__"))
+        link_path = os.path.join(sublime.packages_path(), name)
+        self.assertTrue(os.path.islink(link_path))
+        self.assertEqual(os.path.realpath(link_path), os.path.realpath(self.target_dir))
+
+    def test_resource_becomes_findable(self):
+        code = (
+            "name = temp_packages_link(%r)\n"
+            "import json\n"
+            "_ = json.dumps([name, find_resources('Probe.sublime-syntax')])\n"
+            "print(_)\n"
+        ) % self.syntax_path
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        name, resources = json.loads(outcome["output"].strip())
+        self.addCleanup(self._release, name)
+        expected = "Packages/%s/%s" % (name, self.syntax_basename)
+        self.assertIn(expected, resources)
+
+    def test_release_removes_link(self):
+        code = (
+            "name = temp_packages_link(%r)\n"
+            "release_packages_link(name)\n"
+            "print(name)\n"
+        ) % self.syntax_path
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        name = outcome["output"].strip()
+        link_path = os.path.join(sublime.packages_path(), name)
+        self.assertFalse(os.path.lexists(link_path))
+
+    def test_release_validates_name_prefix(self):
+        # ValueError on a non-temp name; the assertion is that the
+        # error surfaces AND no Packages/ entry was touched.
+        code = "release_packages_link('Markdown')\n"
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("ValueError", outcome["error"])
+        self.assertIn("non-temp", outcome["error"])
+
+    def test_release_idempotent_on_missing(self):
+        # Second release on the same name is a no-op — caller code
+        # using try/finally shouldn't need to track whether the link
+        # was already removed by a sibling sweep.
+        code = (
+            "name = temp_packages_link(%r)\n"
+            "release_packages_link(name)\n"
+            "release_packages_link(name)\n"
+            "print('ok')\n"
+        ) % self.syntax_path
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "ok")
+
+    def test_stale_link_swept_on_next_call(self):
+        # Plant a stale temp symlink with mtime 90 s in the past, then
+        # call temp_packages_link; the head-of-call sweep should
+        # remove the planted link before creating the new one.
+        stale_target = tempfile.mkdtemp(prefix="sublime_mcp_test_stale_target_")
+        self.addCleanup(shutil.rmtree, stale_target, ignore_errors=True)
+        stale_link = os.path.join(
+            sublime.packages_path(), "__sublime_mcp_temp_stalelink__"
+        )
+        if os.path.lexists(stale_link):
+            os.unlink(stale_link)
+        os.symlink(stale_target, stale_link)
+        old = time.time() - 90.0
+        os.utime(stale_link, (old, old), follow_symlinks=False)
+        self.addCleanup(
+            lambda: os.path.lexists(stale_link) and os.unlink(stale_link)
+        )
+        code = (
+            "_ = temp_packages_link(%r)\n"
+            "print(_)\n"
+        ) % self.syntax_path
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        name = outcome["output"].strip()
+        self.addCleanup(self._release, name)
+        self.assertFalse(os.path.lexists(stale_link))


### PR DESCRIPTION
Probing helpers v1 — the cohort of four issues whose comments cross-reference each other repeatedly through late April. Landing them together changes the shape of probe-heavy investigations from "ration probes because each costs ~10 lines of boilerplate and silent failure modes" to "probe freely with structured failure shapes."

Four new helpers under `HELPERS_SOURCE` in `sublime_mcp.py`, with companion recipes in `skills/sublime-mcp/SKILL.md` and tests in `tests/test_helpers.py`:

- `run_on_main(callable, timeout=2.0)` — schedule on ST's main thread, propagate return / exception. Replaces the `set_timeout` + sentinel-list dance previously documented in the gotchas. Direct `view.run_command(...)` from the worker thread is a silent no-op; one regression test locks that.
- `_wait_for_resource` default 1.0 s → 3.0 s (observed 15 s cold-register latency for fresh `.sublime-syntax` files); single main-thread `refresh_folder_list` fired past two-thirds of the budget to nudge ST's indexer.
- `run_inline_syntax_test(content, name)` — same `{state, summary, output, failures}` contract as `run_syntax_tests`, plus an `"inconclusive"` state when ST never indexes the temp resource. Two-layer cleanup: within-call `try/finally`, cross-call mtime sweep for SIGKILL-orphaned dirs older than 60 s.
- `temp_packages_link` / `release_packages_link` — managed `Packages/__sublime_mcp_temp_<nonce>__` symlink for repo-local syntaxes. `release_packages_link` validates the prefix/suffix so a buggy caller can't unlink a real package.

Whole-tree mirror mode for #24 (cross-grammar investigations needing testdata to shadow ST's built-ins) is deferred — tracked in `SKILL.md` §6 as a follow-up; the lifecycle is structurally different and shouldn't fall out of the per-syntax design by accident.

Closes #6, closes #33, closes #30, closes #24.

## Test plan

Beyond CI, manual round-trip after merge per the verification block in the plan file: `run_on_main` actually mutates a buffer, `_wait_for_resource.__defaults__` reads `(3.0,)`, `run_inline_syntax_test` returns `passed` then `failed` on a deliberately-wrong assertion, `temp_packages_link` round-trips a `testdata/` syntax against `resolve_position`. Hard to automate in CI: the manual probe needs an interactive ST window and a real syntax file outside the test harness's temp dir.
