### PR TITLE
Dogfooding pass: seven session-driven paper-cuts

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -57,7 +57,7 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 - Assign to `_` inside the snippet to get its `repr` back as `result`.
 - `error` is populated on uncaught exception; `isError` is derived from `error is not None`. Helper failures (e.g. `run_syntax_tests` cannot complete the run) raise and surface in this same `error` field — there is no separate helper-level error channel.
 - `st_version` (int) and `st_channel` (str, e.g. `"stable"` / `"dev"`) echo the running ST build on every response. Use these to detect channel mismatches when probing grammars whose CI gates on a non-stable channel.
-- `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed`).
+- `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed`). `failures` is ST's raw multi-line diagnostic per assertion; `failures_structured` is the same list parsed into `{file, row, col, error_label, expected_selector, actual}` dicts for programmatic consumers (best-effort; `failures` remains canonical on parser miss).
 - Preloaded helpers (`scope_at`, `scope_at_test`, `resolve_position`, `run_syntax_tests`, `open_view`, `assign_syntax_and_wait`, `find_resources`, `reload_syntax`) are in scope without import.
 
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
@@ -100,10 +100,12 @@ for msg in r["failures"]:
 
 Branch on `state` for the assertion-run outcome:
 
-| `state`     | meaning                                                                          | `summary` shape                                  | `failures`     |
-| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------------ | -------------- |
-| `"passed"`  | runner completed; every assertion matched                                        | assertion-count headline                         | `[]`           |
-| `"failed"`  | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated      |
+| `state`     | meaning                                                                          | `summary` shape                                  | `failures` / `failures_structured` |
+| ----------- | -------------------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------- |
+| `"passed"`  | runner completed; every assertion matched                                        | assertion-count headline                         | `[]` / `[]`                        |
+| `"failed"`  | runner completed; some assertions did not match — read `failures` for specifics  | `"FAILED: N of M assertions failed"`             | populated                          |
+
+`failures_structured[i]` is the parsed peer of `failures[i]` — `{file, row, col, error_label, expected_selector, actual: [{col_range, scope_chain}, ...]}`. The parser is best-effort: on an unexpected line shape any field can be `None` / empty and `failures[i]` remains the canonical record.
 
 When ST cannot complete the run, `run_syntax_tests` raises `RuntimeError` and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. The reachable causes are: resource not yet indexed, path outside `sublime.packages_path()` (symlink it in first — see "Confirm which syntax ST assigned (and handle repo-local syntaxes)" below), and the private `sublime_api.run_syntax_test` missing on this ST build. For ground-truth questions that don't need the assertion runner, fall back to `scope_at` / `scope_at_test` or `resolve_position`.
 
@@ -251,7 +253,7 @@ _Last synced with issue state: 2026-05-04._
 - `scope_at(path, row, col) -> dict` — open file, return `{"scope", "resolved_syntax"}`. `resolved_syntax` is `view.syntax().path` (or `None`); compare against the canonical plain-text URI to detect extension-less / no-syntax fallback.
 - `scope_at_test(path, row, col) -> dict` — parse `# SYNTAX TEST` header, assign that syntax, return `{"scope", "requested_syntax", "resolved_syntax"}`. `requested_syntax != resolved_syntax` flags silent fallback to the wrong syntax.
 - `resolve_position(path, row, col, syntax_path=None) -> dict` — full position disambiguation with `overflow` / `clamped` flags; also carries `requested_syntax` / `resolved_syntax`.
-- `run_syntax_tests(path) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures}`. Path must resolve under `sublime.packages_path()` (directly or via a symlink in that directory); paths outside the Packages tree raise.
+- `run_syntax_tests(path) -> dict` — run ST's built-in syntax-test runner. `{state, summary, output, failures, failures_structured}`. Path must resolve under `sublime.packages_path()` (directly or via a symlink in that directory); paths outside the Packages tree raise.
 - `run_inline_syntax_test(content, name) -> dict` — synthetic-probe variant: writes `content` to a managed temp dir under `Packages/User/`, runs the runner, cleans up. Same shape as `run_syntax_tests` plus a `"inconclusive"` state when ST never indexes the temp resource.
 - `open_view(path, timeout=5.0) -> View` — open a file, poll `is_loading` and initial tokenisation.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None` — assign a syntax and wait for the setting to apply + best-effort tokenisation.

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -213,6 +213,21 @@ _ = candidates
 
 The filter is not pushed inside `find_resources` itself: silent filtering would mask the underlying ST behaviour and cost a `load_resource` per entry on every listing.
 
+### Probe a large syntax-test file in pieces
+
+`run_syntax_tests` drives the private `sublime_api.run_syntax_test`, which is synchronous. For files with thousands of assertions (e.g. `~14k` on a large grammar's `syntax_test_*` fixture) the runner exceeds the 60 s `EXEC_TIMEOUT_SECONDS` ceiling on `exec_sublime_python` and the call returns with `error: "exec timed out after 60s"` rather than a structured `failed` / `passed` payload. No `timeout` parameter on `run_syntax_tests` rescues this — the ceiling is on the snippet call, not the helper.
+
+When that happens, enumerate failing positions externally and probe each one:
+
+```python
+# failing_positions = [(row, col), ...] — produced separately, e.g. by
+# syntect's examples/syntest harness against the same file.
+results = [scope_at_test("/abs/path/to/syntax_test_huge", r, c) for r, c in failing_positions]
+_ = results
+```
+
+`scope_at_test` reads the `# SYNTAX TEST` header and assigns the syntax once per call; the loop pays a one-time tokenisation on first call and then runs at the per-`scope_name` rate noted in *Bulk probes* above. Each call is independent of the 60 s budget.
+
 ## 5. Output discipline
 
 - **Return raw scopes.** `source.python keyword.control.flow` is the answer — don't paraphrase to "it's a Python keyword in a control-flow context." The caller can read the scope; paraphrase drops information.

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -188,14 +188,12 @@ v.set_scratch(True); v.close()
 
 ### Bulk probes
 
-`scope_name` on an already-tokenised view is thread-safe and runs concurrent with ST's UI, so a several-hundred-row sweep in one `exec_sublime_python` call comfortably fits the 60 s per-call budget. The cold-view cost is a one-time tokenisation pass on the first helper call against a given path.
+A `view.scope_name(point)` call on an already-tokenised view costs around 150 µs (measured: 5 × 500-sample medians on a 1.2k-line Python source view, ST 4200 stable). It's also thread-safe and runs concurrent with ST's UI, so a several-hundred-row sweep in one `exec_sublime_python` call comfortably fits the 60 s per-call budget — three orders of magnitude of headroom. The cold-view cost is a one-time tokenisation pass on the first helper call against a given path.
 
 ```python
 scopes = [scope_at("/path/to/big_file", row, 0)["scope"] for row in range(3020, 3039)]
 _ = scopes  # returns via `result`
 ```
-
-Measured per-call latency is tracked in #10.
 
 ### Filter find_resources output through load_resource
 
@@ -245,7 +243,6 @@ _Last synced with issue state: 2026-05-04._
 - **#8** — concurrency cap on the exec daemon-thread pool.
 - **#22** — `resolve_position` `syntax_path` accepts filesystem paths directly (URI flexibility on top of `temp_packages_link`).
 - **whole-tree mirror** (follow-up to #24) — `temp_packages_link` covers per-syntax probing, but cross-grammar investigations where one testdata grammar embeds another (e.g. C# embedding RegExp) need the testdata tree to *shadow* ST's built-ins, not coexist with them. Different lifecycle (parent symlink, per-entry shadowing); not yet implemented.
-- **#10** — documented per-call latency for bulk probes + daemon-thread / cold-tokenisation clarification.
 - **#34** — `find_resources` can list stale `Packages/...` paths whose `load_resource` raises `FileNotFoundError`; documented in §4 ("Filter find_resources output through load_resource").
 
 ## 7. Reference — preloaded helpers

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -54,7 +54,7 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 { "output": "<captured print()>", "result": "<repr(_) or null>", "error": "<traceback or null>", "st_version": 4200, "st_channel": "stable", "isError": false }
 ```
 
-- Assign to `_` inside the snippet to get its `repr` back as `result`.
+- A trailing bare expression is auto-lifted into `_`, or assign to `_` explicitly at top level. Either way, `repr(_)` is returned as `result`.
 - `error` is populated on uncaught exception; `isError` is derived from `error is not None`. Helper failures (e.g. `run_syntax_tests` cannot complete the run) raise and surface in this same `error` field — there is no separate helper-level error channel.
 - `st_version` (int) and `st_channel` (str, e.g. `"stable"` / `"dev"`) echo the running ST build on every response. Use these to detect channel mismatches when probing grammars whose CI gates on a non-stable channel.
 - `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed`). `failures` is ST's raw multi-line diagnostic per assertion; `failures_structured` is the same list parsed into `{file, row, col, error_label, expected_selector, actual}` dicts for programmatic consumers (best-effort; `failures` remains canonical on parser miss).

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -195,6 +195,24 @@ _ = scopes  # returns via `result`
 
 Measured per-call latency is tracked in #10.
 
+### Filter find_resources output through load_resource
+
+`find_resources` reports whatever ST's resource index says exists, which can lag behind reality. A path like `Packages/C#/Embeddings/Regex (for C#).sublime-syntax` may appear in the listing yet raise `FileNotFoundError` from `sublime.load_resource(...)` when the underlying file is gone (cache survives source). Filter at the call site:
+
+```python
+def _safe_load(p):
+    try:
+        sublime.load_resource(p)
+        return True
+    except FileNotFoundError:
+        return False
+
+candidates = [p for p in find_resources("*.sublime-syntax") if _safe_load(p)]
+_ = candidates
+```
+
+The filter is not pushed inside `find_resources` itself: silent filtering would mask the underlying ST behaviour and cost a `load_resource` per entry on every listing.
+
 ## 5. Output discipline
 
 - **Return raw scopes.** `source.python keyword.control.flow` is the answer — don't paraphrase to "it's a Python keyword in a control-flow context." The caller can read the scope; paraphrase drops information.
@@ -211,7 +229,7 @@ _Last synced with issue state: 2026-05-04._
 - **#22** — `resolve_position` `syntax_path` accepts filesystem paths directly (URI flexibility on top of `temp_packages_link`).
 - **whole-tree mirror** (follow-up to #24) — `temp_packages_link` covers per-syntax probing, but cross-grammar investigations where one testdata grammar embeds another (e.g. C# embedding RegExp) need the testdata tree to *shadow* ST's built-ins, not coexist with them. Different lifecycle (parent symlink, per-entry shadowing); not yet implemented.
 - **#10** — documented per-call latency for bulk probes + daemon-thread / cold-tokenisation clarification.
-- **#34** — `find_resources` lists `Packages/...` paths whose `load_resource` raises `FileNotFoundError` (cache-survives-source case observed against `Packages/C#/Embeddings/Regex (for C#).sublime-syntax`); characterise before deciding doc vs code fix.
+- **#34** — `find_resources` can list stale `Packages/...` paths whose `load_resource` raises `FileNotFoundError`; documented in §4 ("Filter find_resources output through load_resource").
 
 ## 7. Reference — preloaded helpers
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -73,14 +73,19 @@ them in `run_on_main(...)`. The following names are preloaded:
   `requested_syntax` (echo of the `syntax_path` arg, or `None`) and
   `resolved_syntax` (ST's `view.syntax().path`, or `None`).
 - `run_syntax_tests(path) -> dict` — returns
-  `{"state": str, "summary": str, "output": str, "failures": list[str]}`.
+  `{"state": str, "summary": str, "output": str,
+    "failures": list[str], "failures_structured": list[dict]}`.
   `state` is one of `"passed"` (all assertions matched) or
   `"failed"` (the runner completed but some assertions did not
   match). `summary` is an assertion-count headline. `failures` is
   one entry per failed assertion with ST's own diagnostic
   (file:row:col, "error: scope does not match", then the
   expected/actual snippet); populated only when
-  `state == "failed"`. Cases where ST cannot complete the run
+  `state == "failed"`. `failures_structured` is the same list parsed
+  into `{file, row, col, error_label, expected_selector,
+  actual: [{col_range, scope_chain}, ...]}` dicts — best-effort
+  enrichment for programmatic consumers, with `failures` as the
+  canonical record on parser miss. Cases where ST cannot complete the run
   (resource not yet indexed, path outside `sublime.packages_path()`,
   private `sublime_api.run_syntax_test` missing) raise
   `RuntimeError`, surfaced in the top-level `error` field of the
@@ -96,7 +101,8 @@ them in `run_on_main(...)`. The following names are preloaded:
 - `run_inline_syntax_test(content, name) -> dict` — for synthetic
   probes ("what does ST do on this case?"). Writes `content` to a
   per-call temp dir under `Packages/User/`, runs ST's syntax-test
-  runner, cleans up. Same `{state, summary, output, failures}`
+  runner, cleans up. Same
+  `{state, summary, output, failures, failures_structured}`
   contract as `run_syntax_tests`, plus a third state
   `"inconclusive"` when ST never indexes the temp resource within
   the wait budget (looser than `run_syntax_tests`, which raises —
@@ -658,7 +664,83 @@ def _run_syntax_tests_via_api(path):
         "summary": summary,
         "output": "\n".join(failures) if failures else summary,
         "failures": failures,
+        "failures_structured": [_parse_failure_message(m) for m in failures],
     }
+
+
+def _parse_failure_message(msg):
+    # Best-effort parser for the multi-line strings sublime_api.run_syntax_test
+    # returns. The format is undocumented (private API) so the parser never
+    # raises: on any unexpected shape, the dict carries None / empty fields and
+    # the raw string remains the canonical record under `failures`.
+    out = {
+        "file": None,
+        "row": None,
+        "col": None,
+        "error_label": "",
+        "expected_selector": None,
+        "actual": [],
+    }
+    if not msg:
+        return out
+    lines = msg.splitlines()
+    if not lines:
+        return out
+    head = lines[0]
+    parts = head.rsplit(":", 2)
+    if len(parts) == 3:
+        out["file"] = parts[0] or None
+        try:
+            out["row"] = int(parts[1])
+            out["col"] = int(parts[2])
+        except ValueError:
+            pass
+    if len(lines) > 1 and lines[1].startswith("error:"):
+        out["error_label"] = lines[1].split(":", 1)[1].strip()
+    actual_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "actual:":
+            actual_idx = i
+            break
+    end = actual_idx if actual_idx is not None else len(lines)
+    # Expected selector: first line in the assertion block whose body has a
+    # comment marker before the caret. The diagnostic "this location did not
+    # match" line has only whitespace before the caret and is skipped.
+    for line in lines[2:end]:
+        body_split = line.split("|", 1)
+        if len(body_split) != 2:
+            continue
+        body = body_split[1]
+        caret = body.find("^")
+        if caret < 0:
+            continue
+        prefix = body[:caret]
+        if not prefix.strip():
+            continue
+        rest = body[caret + 1:].lstrip("^").lstrip(" ").rstrip()
+        if rest:
+            out["expected_selector"] = rest
+            break
+    if actual_idx is not None:
+        for line in lines[actual_idx + 1:]:
+            body_split = line.split("|", 1)
+            if len(body_split) != 2:
+                continue
+            body = body_split[1]
+            caret_start = body.find("^")
+            if caret_start < 0:
+                continue
+            caret_end = caret_start
+            while caret_end < len(body) and body[caret_end] == "^":
+                caret_end += 1
+            col_range = body[caret_start:caret_end]
+            scope_chain = body[caret_end:].strip()
+            if scope_chain:
+                out["actual"].append({
+                    "col_range": col_range,
+                    "scope_chain": scope_chain,
+                })
+    return out
 
 
 def _is_unable_to_read(messages):
@@ -852,6 +934,7 @@ def run_inline_syntax_test(content, name):
                 "summary": "Sublime Text has not indexed the resource at %s" % resource,
                 "output": "",
                 "failures": [],
+                "failures_structured": [],
             }
         total, messages = _sublime_api.run_syntax_test(resource)
         if _is_unable_to_read(messages):
@@ -863,6 +946,7 @@ def run_inline_syntax_test(content, name):
                 "summary": "Sublime Text could not read %s after indexing wait" % resource,
                 "output": "",
                 "failures": [],
+                "failures_structured": [],
             }
         failures = list(messages)
         if failures:
@@ -871,12 +955,14 @@ def run_inline_syntax_test(content, name):
                 "summary": "FAILED: %d of %d assertions failed" % (len(failures), total),
                 "output": "\n".join(failures),
                 "failures": failures,
+                "failures_structured": [_parse_failure_message(m) for m in failures],
             }
         return {
             "state": "passed",
             "summary": "%d assertions passed" % total,
             "output": "%d assertions passed" % total,
             "failures": [],
+            "failures_structured": [],
         }
     finally:
         import shutil as _shutil

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -86,9 +86,13 @@ them in `run_on_main(...)`. The following names are preloaded:
   `RuntimeError`, surfaced in the top-level `error` field of the
   MCP response — the same channel any other helper failure uses.
   Files outside Packages/ must be symlinked in (the helper walks
-  symlinks); see SKILL.md section 4. Files with thousands of
-  assertions can exceed the 60 s ceiling on the runner itself;
-  see SKILL.md section 4 for the per-position-probe workaround.
+  symlinks); see SKILL.md section 4. The runner is synchronous and
+  counts against the 60 s `EXEC_TIMEOUT_SECONDS` ceiling on
+  `exec_sublime_python`; on overrun the response carries
+  `error: "exec timed out after 60s"` rather than a structured
+  helper-level state. Files with thousands of assertions can exceed
+  that ceiling; see SKILL.md section 4 for the per-position-probe
+  workaround.
 - `run_inline_syntax_test(content, name) -> dict` — for synthetic
   probes ("what does ST do on this case?"). Writes `content` to a
   per-call temp dir under `Packages/User/`, runs ST's syntax-test

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -9,6 +9,7 @@ Security: binds 127.0.0.1 only; exec'ing arbitrary Python is equivalent to
 an open console. Do not expose the port beyond localhost.
 """
 
+import ast
 import builtins as _builtins
 import io
 import json
@@ -163,8 +164,13 @@ regardless of row wrapping.
 
 ## Output protocol
 
-Anything you `print(...)` is captured and returned as `output`. If you
-assign a value to `_`, its `repr` is returned as `result`. Exceptions
+Anything you `print(...)` is captured and returned as `output`. If your
+snippet ends with a bare expression it is auto-lifted into `_` and
+`repr(_)` is returned as `result`; explicit `_ = ...` at the snippet's
+top level wins (any nested assignment, including inside `if`, `for`, a
+function body, etc., leaves the lift enabled). On a `SyntaxError` the
+snippet is compiled directly so the traceback shape callers see is
+unchanged. Exceptions
 are caught, formatted, and returned as `error` (with whatever was
 printed up to that point still in `output`). Only `print(...)` is
 captured — direct writes to `sys.stderr` / `sys.stdout` are not,
@@ -998,6 +1004,38 @@ def run_syntax_tests(path):
 _HELPERS_CODE = compile(HELPERS_SOURCE, "<sublime-mcp-helpers>", "exec")
 
 
+def _compile_snippet(code):
+    # REPL-style auto-lift: if the snippet ends in a bare expression and
+    # does not assign to `_` at module level, rewrite the trailing Expr
+    # into `_ = <expr>` so callers don't have to remember the idiom.
+    # Strict scope on the explicit-assign check (top-level `tree.body`
+    # only) — `for _ in ...`, `_ = 1` inside `if False:`, or a nested-
+    # function assign all leave the lift enabled.
+    # SyntaxError falls through to the original compile so the
+    # traceback shape callers see is unchanged.
+    try:
+        tree = ast.parse(code, mode="exec")
+    except SyntaxError:
+        return compile(code, "<sublime-mcp-snippet>", "exec")
+    if not tree.body or not isinstance(tree.body[-1], ast.Expr):
+        return compile(tree, "<sublime-mcp-snippet>", "exec")
+    has_explicit_underscore = any(
+        isinstance(stmt, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "_" for t in stmt.targets)
+        for stmt in tree.body
+    )
+    if has_explicit_underscore:
+        return compile(tree, "<sublime-mcp-snippet>", "exec")
+    last = tree.body[-1]
+    tree.body[-1] = ast.Assign(
+        targets=[ast.Name(id="_", ctx=ast.Store())],
+        value=last.value,
+    )
+    ast.copy_location(tree.body[-1], last)
+    ast.fix_missing_locations(tree)
+    return compile(tree, "<sublime-mcp-snippet>", "exec")
+
+
 def _exec_on_worker(code):
     """Run `code` on a dedicated daemon thread and collect output.
 
@@ -1043,7 +1081,8 @@ def _exec_on_worker(code):
             done.set()
             return
         try:
-            exec(compile(code, "<sublime-mcp-snippet>", "exec"), namespace)
+            compiled = _compile_snippet(code)
+            exec(compiled, namespace)
             if "_" in namespace and namespace["_"] is not None:
                 try:
                     result["result"] = repr(namespace["_"])

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -335,6 +335,28 @@ v.close()
   ST removes it, `run_syntax_tests` raises rather than silently
   degrading.
 
+## Commonly misremembered ST API names
+
+A few names that look right but aren't — worth double-checking via
+`dir(sublime)` / `dir(view)` from a snippet before relying on them:
+
+- `sublime.syntax_from_path(resource_path)` — direct lookup by
+  `Packages/...` URI; returns `Syntax | None`. There is no
+  `find_syntax_by_path`.
+- `sublime.find_syntax_for_file(path, first_line=None)` —
+  content-aware resolution (extension + first-line match). Distinct
+  from `syntax_from_path`, which is a direct URI lookup.
+- `view.scope_name(point)` — returns the scope chain at a point. The
+  helper `scope_at(...)` in this tool wraps it; there is no
+  `view.scope_at`.
+- `view.syntax()` returns `Syntax | None` — the honest signal.
+  `view.settings().get("syntax")` echoes whatever string was passed
+  to `assign_syntax`, including bogus URIs, and cannot detect silent
+  fallback.
+- `sublime.load_resource(path)` raises `FileNotFoundError` on stale
+  index entries surfaced by `find_resources`; see SKILL.md §4 for the
+  try-load-and-skip filter.
+
 ## Companion skill
 
 A Claude Code skill with workflow recipes for this tool is bundled at

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -86,7 +86,9 @@ them in `run_on_main(...)`. The following names are preloaded:
   `RuntimeError`, surfaced in the top-level `error` field of the
   MCP response — the same channel any other helper failure uses.
   Files outside Packages/ must be symlinked in (the helper walks
-  symlinks); see SKILL.md section 4.
+  symlinks); see SKILL.md section 4. Files with thousands of
+  assertions can exceed the 60 s ceiling on the runner itself;
+  see SKILL.md section 4 for the per-position-probe workaround.
 - `run_inline_syntax_test(content, name) -> dict` — for synthetic
   probes ("what does ST do on this case?"). Writes `content` to a
   per-call temp dir under `Packages/User/`, runs ST's syntax-test

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -334,6 +334,12 @@ v.close()
 ## Gotchas
 
 - Hard timeout per call is 60 s.
+- A `view.scope_name(point)` call on an already-tokenised view costs
+  around 150 µs (measured: 5 × 500-sample medians on a 1.2k-line
+  Python source view, ST 4200 stable); a several-hundred-position
+  sweep fits the 60 s ceiling with three orders of magnitude of
+  headroom. The cold-view cost is a one-time tokenisation pass on
+  the first helper call against a given path.
 - The snippet runs on a dedicated daemon thread (not ST's async
   worker and not the main UI thread). Most of the ST API is
   thread-safe, but a few mutating operations (`TextCommand` edit

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -422,6 +422,61 @@ class TestRunSyntaxTestsApiPath(HelperTestBase):
         self.assertIsNotNone(outcome["error"])
         self.assertIn("not indexed", outcome["error"])
 
+    def test_failure_carries_structured_field(self):
+        path = self._write_fixture(
+            "syntax_test_struct",
+            HEADER
+            + "x = 1\n# ^ source.python\n"
+            + "y = 2\n# ^ keyword.control.flow\n",
+        )
+        r = yield from self._run(path)
+        self.assertEqual(r["state"], "failed", r)
+        self.assertEqual(len(r["failures_structured"]), 1, r)
+        s = r["failures_structured"][0]
+        self.assertIsNotNone(s["file"], s)
+        self.assertTrue(s["file"].endswith("syntax_test_struct"), s)
+        self.assertIsInstance(s["row"], int)
+        self.assertIsInstance(s["col"], int)
+        self.assertEqual(s["error_label"], "scope does not match", s)
+        self.assertEqual(s["expected_selector"], "keyword.control.flow", s)
+        self.assertGreaterEqual(len(s["actual"]), 1, s)
+        self.assertIn("source.python", s["actual"][0]["scope_chain"])
+
+    def test_passed_run_has_empty_structured_failures(self):
+        path = self._write_fixture(
+            "syntax_test_pass_struct",
+            HEADER + "x = 1\n# ^ source.python\n",
+        )
+        r = yield from self._run(path)
+        self.assertEqual(r["state"], "passed", r)
+        self.assertEqual(r["failures_structured"], [])
+
+    def test_structured_parser_does_not_raise_on_unparseable(self):
+        # _parse_failure_message is in the helper namespace; call it
+        # directly with deliberately-malformed inputs to assert never-
+        # raises and that every result carries the documented keys.
+        code = (
+            "import json\n"
+            "probes = [\n"
+            "    '',\n"
+            "    'garbage',\n"
+            "    'no:colons here',\n"
+            "    'a:b:c\\nerror: x\\nactual:\\n  | ^ s\\n',\n"
+            "]\n"
+            "_ = [_parse_failure_message(p) for p in probes]\n"
+            "print(json.dumps(_))\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        parsed = json.loads(outcome["output"])
+        self.assertEqual(len(parsed), 4)
+        expected_keys = {
+            "file", "row", "col", "error_label", "expected_selector", "actual",
+        }
+        for entry in parsed:
+            self.assertEqual(set(entry.keys()), expected_keys, entry)
+
     def _run(self, path):
         # Generator: callers must `yield from self._run(...)`.
         code = (

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -820,6 +820,54 @@ class TestRunOnMain(HelperTestBase):
         self.assertEqual(outcome["output"].strip(), "5")
 
 
+class TestUnderscoreAutoLift(HelperTestBase):
+    """REPL-style auto-lift in `_compile_snippet`: a trailing bare
+    expression becomes `_ = <expr>` so callers don't need the explicit
+    idiom. Strict scope on the explicit-assign check (top-level only).
+    """
+
+    def test_trailing_expr_lifted_to_underscore(self):
+        resp = yield from _call_tool_yielding("42\n")
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["result"], "42")
+
+    def test_explicit_top_level_underscore_blocks_lift(self):
+        # Explicit `_ = 1` at top level wins; the trailing `2` is not lifted.
+        resp = yield from _call_tool_yielding("_ = 1\n2\n")
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["result"], "1")
+
+    def test_for_target_named_underscore_does_not_block_lift(self):
+        # `for _ in ...` is ast.For, not ast.Assign; lift should still fire.
+        resp = yield from _call_tool_yielding("for _ in range(3): pass\n42\n")
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["result"], "42")
+
+    def test_nested_underscore_assign_does_not_block_lift(self):
+        # `_ = 1` inside `if False:` is not at top level — strict check skips it.
+        code = "if False:\n    _ = 1\n42\n"
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["result"], "42")
+
+    def test_trailing_statement_does_not_lift(self):
+        # `x = 1` is ast.Assign, not ast.Expr — nothing to lift.
+        resp = yield from _call_tool_yielding("x = 1\n")
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertIsNone(outcome["result"])
+
+    def test_syntax_error_falls_through(self):
+        resp = yield from _call_tool_yielding("def\n")
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("SyntaxError", outcome["error"])
+
+
 class TestWaitForResource(HelperTestBase):
     """`_wait_for_resource` widened from 1.0 s to 3.0 s and gained a
     one-shot `refresh_folder_list` nudge past two-thirds of the budget


### PR DESCRIPTION
Dogfooding pass on the helper surface — seven session-driven paper-cuts. Each commit is independent and points at the specific code or doc location it fixes; rationale lives in the linked issues, not duplicated here.

Closes #48. Closes #34. Closes #36. Closes #31. Closes #39. Closes #21. Closes #10.

## Test plan

- New tests under `TestRunSyntaxTestsApiPath` cover the `failures_structured` field on pass / fail and parser robustness on malformed input.
- New `TestUnderscoreAutoLift` class covers the six lift / no-lift / fall-through paths.
- `~150 µs` figure for `view.scope_name` was a 5 × 500-sample median on `tests/test_helpers.py` against `Packages/Python/Python.sublime-syntax`, ST 4200 stable.
