### PR TITLE
Accept filesystem-path syntaxes in resolve_position / assign_syntax_and_wait

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -129,14 +129,15 @@ Same `{state, summary, output, failures}` shape as `run_syntax_tests`, with one 
 
 `view.assign_syntax` takes a `Packages/...` resource URI, not an arbitrary filesystem path. The older `view.set_syntax_file` has the same constraint but fails silently when given a filesystem path: `view.settings().get("syntax")` echoes the assigned absolute path, ST surfaces a "file not found" popup, `view.scope_name(...)` returns `text.plain` for every position, and the Python call doesn't raise. Prefer `assign_syntax_and_wait`.
 
-For a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), use `temp_packages_link` to manage a per-call symlink. The helper synthesises `Packages/__sublime_mcp_temp_<nonce>__`, waits for ST's resource indexer to surface the sentinel, and returns the synthesised package name. The caller builds URIs against it and tears down via `release_packages_link`.
+For a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), use `temp_packages_link` to manage a per-call symlink. The helper synthesises `Packages/__sublime_mcp_temp_<nonce>__`, waits for ST's resource indexer to surface the sentinel, and returns the synthesised package name. Pass the syntax's filesystem path directly to `resolve_position` / `assign_syntax_and_wait` — the helpers reverse-map filesystem inputs through any symlink in `sublime.packages_path()` to the matching `Packages/...` URI. (Constructing the URI by hand as `"Packages/%s/Java.sublime-syntax" % name` still works.) The caller tears down via `release_packages_link`.
 
 ```python
-name = temp_packages_link("/path/to/repo/testdata/Packages/Java/Java.sublime-syntax")
+syntax_path = "/path/to/repo/testdata/Packages/Java/Java.sublime-syntax"
+name = temp_packages_link(syntax_path)
 try:
     r = resolve_position(
         "/path/to/syntax_test_file", row=71, col=29,
-        syntax_path="Packages/%s/Java.sublime-syntax" % name,
+        syntax_path=syntax_path,
     )
     print(r["scope"], "overflow:", r["overflow"], "clamped:", r["clamped"])
     assert r["resolved_syntax"] == r["requested_syntax"], r
@@ -241,7 +242,6 @@ _Last synced with issue state: 2026-05-04._
 
 - **#7** — parameterise the test suite's hardcoded `HEADER` across syntaxes.
 - **#8** — concurrency cap on the exec daemon-thread pool.
-- **#22** — `resolve_position` `syntax_path` accepts filesystem paths directly (URI flexibility on top of `temp_packages_link`).
 - **whole-tree mirror** (follow-up to #24) — `temp_packages_link` covers per-syntax probing, but cross-grammar investigations where one testdata grammar embeds another (e.g. C# embedding RegExp) need the testdata tree to *shadow* ST's built-ins, not coexist with them. Different lifecycle (parent symlink, per-entry shadowing); not yet implemented.
 - **#34** — `find_resources` can list stale `Packages/...` paths whose `load_resource` raises `FileNotFoundError`; documented in §4 ("Filter find_resources output through load_resource").
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -70,9 +70,14 @@ them in `run_on_main(...)`. The following names are preloaded:
 - `resolve_position(path, row, col, syntax_path=None) -> dict` —
   returns the full position disambiguation for `(row, col)`. See
   "text_point overflow" below. Optional `syntax_path` calls
-  `assign_syntax_and_wait` on the view first. Response carries
-  `requested_syntax` (echo of the `syntax_path` arg, or `None`) and
-  `resolved_syntax` (ST's `view.syntax().path`, or `None`).
+  `assign_syntax_and_wait` on the view first; accepts either a
+  `Packages/...` URI or a filesystem path under `sublime.packages_path()`
+  (directly or via a symlink in that directory). Response carries
+  `requested_syntax` (the `Packages/...` URI ST was asked for —
+  filesystem-form inputs are normalised to URI form so the equality
+  check below still works; `None` when `syntax_path` was omitted) and
+  `resolved_syntax` (ST's `view.syntax().path`, or `None`). Compare the
+  two for silent-fallback detection.
 - `run_syntax_tests(path) -> dict` — returns
   `{"state": str, "summary": str, "output": str,
     "failures": list[str], "failures_structured": list[dict]}`.
@@ -119,7 +124,10 @@ them in `run_on_main(...)`. The following names are preloaded:
   `is_loading()` up to 5 s, returns the View.
 - `assign_syntax_and_wait(view, resource_path, timeout=2.0) -> None`
   — assigns a syntax and best-effort waits for tokenisation to touch
-  point 0. Stage 1 (wait for the syntax setting to apply) is
+  point 0. `resource_path` accepts either a `Packages/...` URI or a
+  filesystem path under `sublime.packages_path()` (directly or via a
+  symlink in that directory); paths outside that tree raise
+  `ValueError`. Stage 1 (wait for the syntax setting to apply) is
   deterministic; stage 2 (tokenisation) is best-effort — ST has no
   public tokenisation-complete signal. For large files, re-read
   `scope_name` after use rather than trusting the helper.
@@ -480,6 +488,21 @@ def assign_syntax_and_wait(view, resource_path, timeout=2.0):
     # views from a headless ST (no window) — so `view.size() > 0` need
     # not be re-asserted here. A direct caller bypassing `open_view` on
     # a zero-size view will time out on stage 1 below.
+    # `view.assign_syntax` requires a `Packages/...` URI; route a
+    # filesystem-form input through `_to_resource_path` (passthrough
+    # for inputs already in `Packages/...` form). Reachable inputs
+    # outside the Packages tree are the caller's bug — surface them
+    # rather than silently passing through to ST and falling back to
+    # text.plain (the failure shape #11 hardened scope_at against).
+    converted = _to_resource_path(resource_path)
+    if converted is None:
+        raise ValueError(
+            "assign_syntax_and_wait: %r is not under sublime.packages_path() "
+            "(directly or via a symlink in that directory). Use "
+            "temp_packages_link to make a repo-local syntax reachable first."
+            % resource_path
+        )
+    resource_path = converted
     # ST exposes no public tokenisation-complete signal. Stage 1 waits for
     # view.settings()["syntax"] to reflect the requested path (usually one
     # tick, but guards against a typo landing silently). Stage 2 is a
@@ -540,6 +563,21 @@ def scope_at_test(path, row, col):
 def resolve_position(path, row, col, syntax_path=None):
     view = open_view(path)
     if syntax_path is not None:
+        # Convert here too (not just inside assign_syntax_and_wait) so
+        # `requested_syntax` echoes the URI ST actually saw. Otherwise a
+        # filesystem-form input breaks the `resolved_syntax == requested_syntax`
+        # equality contract that callers use for silent-fallback detection (#11).
+        # The repeat call inside assign_syntax_and_wait is a passthrough on the
+        # already-resource-form URI.
+        converted = _to_resource_path(syntax_path)
+        if converted is None:
+            raise ValueError(
+                "resolve_position: %r is not under sublime.packages_path() "
+                "(directly or via a symlink in that directory). Use "
+                "temp_packages_link to make a repo-local syntax reachable first."
+                % syntax_path
+            )
+        syntax_path = converted
         assign_syntax_and_wait(view, syntax_path)
     point = view.text_point(row, col)
     real_row, real_col = view.rowcol(point)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1382,3 +1382,143 @@ class _FakeWindow:
         v1_calls, v2_calls = json.loads(outcome["output"])
         self.assertEqual(v1_calls, ["Packages/Python/Python.sublime-syntax"])
         self.assertEqual(v2_calls, ["Packages/Python/Python.sublime-syntax"])
+
+
+@unittest.skipIf(
+    sys.platform == "win32",
+    "TestResolvePositionFilesystemSyntax requires symlink creation, "
+    "which needs SeCreateSymbolicLinkPrivilege or Developer Mode on "
+    "Windows. Same constraint as TestToResourcePathSymlinked.",
+)
+class TestResolvePositionFilesystemSyntax(HelperTestBase):
+    """`resolve_position`'s `syntax_path` accepts a filesystem path under
+    `sublime.packages_path()` (directly or via a symlink in that
+    directory) and normalises it to a `Packages/...` URI before
+    calling `assign_syntax_and_wait`. The normalisation is what keeps
+    the #11 silent-fallback contract (`resolved_syntax ==
+    requested_syntax` equality) meaningful when callers pass
+    filesystem paths — the equality itself is not re-asserted here
+    because fresh temp syntaxes race ST's syntax-loader latency; see
+    the per-test comments.
+
+    Reuses `TestTempPackagesLink`'s syntax-fixture pattern: synthesise
+    a `.sublime-syntax` under a tempdir, link it into Packages/ via
+    `temp_packages_link`, then probe.
+    """
+
+    SYNTAX_CONTENT = (
+        "%YAML 1.2\n"
+        "---\n"
+        "name: SublimeMcpResolvePositionProbe\n"
+        "scope: source.smrpp\n"
+        "file_extensions: [smrpp]\n"
+        "version: 2\n"
+        "contexts:\n"
+        "  main:\n"
+        "    - match: 'x'\n"
+        "      scope: keyword.smrpp\n"
+    )
+
+    SYNTAX_BASENAME = "Probe.sublime-syntax"
+
+    def setUp(self):
+        self._defensive_link_sweep()
+        self.target_dir = tempfile.mkdtemp(prefix="sublime_mcp_test_resolve_")
+        self.addCleanup(shutil.rmtree, self.target_dir, ignore_errors=True)
+        self.syntax_path = os.path.join(self.target_dir, self.SYNTAX_BASENAME)
+        with open(self.syntax_path, "w") as f:
+            f.write(self.SYNTAX_CONTENT)
+        # Plain text fixture for resolve_position's `path` arg — the
+        # syntax assignment is what's under test, not the file's
+        # default-syntax inference.
+        self.fixture_path = self._write_fixture("filesystem_syntax", "x = 1\n")
+
+    def _defensive_link_sweep(self):
+        # Same as TestTempPackagesLink — clean stale temp symlinks
+        # left behind by a prior crashed run.
+        packages_root = sublime.packages_path()
+        for name in os.listdir(packages_root):
+            if not (name.startswith("__sublime_mcp_temp_") and name.endswith("__")):
+                continue
+            full = os.path.join(packages_root, name)
+            if os.path.islink(full):
+                try:
+                    os.unlink(full)
+                except OSError:
+                    pass
+
+    def _release(self, name):
+        link_path = os.path.join(sublime.packages_path(), name)
+        if os.path.lexists(link_path) and os.path.islink(link_path):
+            os.unlink(link_path)
+
+    def test_filesystem_path_normalises_to_packages_uri(self):
+        # The #22 contract is the normalisation: a filesystem-form
+        # syntax_path is rewritten to Packages/<name>/... before being
+        # echoed as `requested_syntax`. That is what this class pins.
+        # Deliberately NOT asserting resolved_syntax: ST's resource
+        # indexer (find_resources, which temp_packages_link waits for)
+        # and its syntax-loader (which view.syntax() reads) have
+        # different latencies for fresh syntaxes — view.syntax() can
+        # still be None when the resource has surfaced, leading to a
+        # racy assertion. The resolved_syntax==requested_syntax
+        # silent-fallback contract from #11 is exercised by
+        # TestResolvePosition.test_in_bounds_no_flags_set against the
+        # bundled Python syntax (no fresh-syntax race).
+        code = (
+            "import json\n"
+            "name = temp_packages_link(%r)\n"
+            "try:\n"
+            "    r = resolve_position(%r, 0, 0, syntax_path=%r)\n"
+            "    print(json.dumps([name, r]))\n"
+            "finally:\n"
+            "    release_packages_link(name)\n"
+        ) % (self.syntax_path, self.fixture_path, self.syntax_path)
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        name, r = json.loads(outcome["output"])
+        expected_uri = "Packages/%s/%s" % (name, self.SYNTAX_BASENAME)
+        self.assertEqual(r["requested_syntax"], expected_uri)
+
+    def test_packages_uri_input_still_works(self):
+        # Regression-proofing: the existing `Packages/...` URI form
+        # passes through `_to_resource_path` unchanged. Tests that #22
+        # didn't break the original contract. resolved_syntax is again
+        # not asserted (same fresh-syntax race as the sibling test).
+        code = (
+            "import json\n"
+            "name = temp_packages_link(%r)\n"
+            "try:\n"
+            "    uri = 'Packages/%%s/%s' %% name\n"
+            "    r = resolve_position(%r, 0, 0, syntax_path=uri)\n"
+            "    print(json.dumps([name, r]))\n"
+            "finally:\n"
+            "    release_packages_link(name)\n"
+        ) % (self.syntax_path, self.SYNTAX_BASENAME, self.fixture_path)
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        name, r = json.loads(outcome["output"])
+        expected_uri = "Packages/%s/%s" % (name, self.SYNTAX_BASENAME)
+        self.assertEqual(r["requested_syntax"], expected_uri)
+
+    def test_outside_packages_filesystem_path_raises(self):
+        # A filesystem path with no symlink chain into Packages/ must
+        # raise ValueError pointing at temp_packages_link, not silently
+        # pass through to view.assign_syntax (which would fall back to
+        # text.plain — the failure mode #11 hardened against).
+        unreachable = tempfile.mkdtemp(prefix="sublime_mcp_test_unreachable_")
+        self.addCleanup(shutil.rmtree, unreachable, ignore_errors=True)
+        unreachable_syntax = os.path.join(unreachable, self.SYNTAX_BASENAME)
+        with open(unreachable_syntax, "w") as f:
+            f.write(self.SYNTAX_CONTENT)
+        code = (
+            "resolve_position(%r, 0, 0, syntax_path=%r)\n"
+        ) % (self.fixture_path, unreachable_syntax)
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNotNone(outcome["error"])
+        self.assertIn("ValueError", outcome["error"])
+        self.assertIn("not under sublime.packages_path()", outcome["error"])
+        self.assertIn("temp_packages_link", outcome["error"])


### PR DESCRIPTION
Closes #22.

`view.assign_syntax` requires a `Packages/...` URI; this routes filesystem-form inputs through `_to_resource_path` (`sublime_mcp.py:582-636`) at the top of `assign_syntax_and_wait` and (for `requested_syntax` echo correctness) again in `resolve_position`. Paths outside `sublime.packages_path()` raise `ValueError` pointing at `temp_packages_link`, rather than silently passing through and falling back to text.plain — same anti-silent-fallback shape as #11.

`requested_syntax` now echoes the URI ST was asked for (filesystem inputs are normalised), so the `resolved_syntax == requested_syntax` equality check still works. SKILL.md §4's `temp_packages_link` recipe is updated to demonstrate the simpler filesystem-path call. The §6 tracking entry for #22 drops; the symlink-workaround paragraph remains load-bearing pending a whole-tree-mirror follow-up.

`scope_at_test` is unaffected: `SYNTAX TEST` headers are conventionally `Packages/...` form already, so `_to_resource_path` is a passthrough at line 598. `reload_syntax` is intentionally left alone — its `resource_path` argument is matched against `view.settings().get("syntax")` which always carries URI form.
