### PR TITLE
Stdio MCP harness that runs sublime-mcp in Docker

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -1,0 +1,23 @@
+name: harness-smoke
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  harness-smoke-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Pre-build the image
+        # Done as a separate step so build time is visible in CI logs
+        # and the test step only measures container boot + readiness.
+        run: docker build -t sublime-mcp-harness:latest .
+      - name: Run harness smoke test
+        run: python3 tests/test_harness_smoke.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Headless Sublime Text image with sublime_mcp.py preloaded.
+#
+# Boots Xvfb on :1, launches `subl --stay /work`, and lets
+# plugin_loaded() bind sublime-mcp's HTTP server on 127.0.0.1:47823
+# inside the container. A volume can be mounted at /work.
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    DISPLAY=:1
+
+# GTK + locales are the same dependency set SublimeText/UnitTesting's
+# Docker image uses for headless ST. Xvfb provides the virtual display;
+# psmisc gives `pkill` (used by the entrypoint's shutdown trap).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        locales \
+        locales-all \
+        psmisc \
+        xvfb \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+
+# Sublime HQ's official apt repo (stable channel). Avoids the
+# scrape-the-download-page dance and keeps version selection in
+# upstream's hands.
+RUN install -d /etc/apt/keyrings \
+ && curl -fsSL https://download.sublimetext.com/sublimehq-pub.gpg \
+      | gpg --dearmor -o /etc/apt/keyrings/sublimehq-archive.gpg \
+ && echo "deb [signed-by=/etc/apt/keyrings/sublimehq-archive.gpg] https://download.sublimetext.com/ apt/stable/" \
+      > /etc/apt/sources.list.d/sublime-text.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends sublime-text \
+ && rm -rf /var/lib/apt/lists/*
+
+# ST's per-user state goes under $HOME. We run as root inside the
+# container; that's fine for an ephemeral, single-tenant sandbox.
+RUN mkdir -p /root/.config/sublime-text/Packages/User
+COPY sublime_mcp.py /root/.config/sublime-text/Packages/User/sublime_mcp.py
+# Pin User-package plugins to ST's Python 3.8 host. Without this, ST's
+# Linux build routes the User package to the 3.3 host, where
+# `from http.server import ThreadingHTTPServer` (added in 3.7) fails
+# to import silently and `plugin_loaded()` is never called.
+RUN echo "3.8" > /root/.config/sublime-text/Packages/User/.python-version
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 47823
+
+WORKDIR /work
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,70 +1,72 @@
 # sublime-mcp
 
 [![tests](https://github.com/stefanobaghino/sublime-mcp/actions/workflows/tests.yml/badge.svg)](https://github.com/stefanobaghino/sublime-mcp/actions/workflows/tests.yml)
+[![harness-smoke](https://github.com/stefanobaghino/sublime-mcp/actions/workflows/harness-smoke.yml/badge.svg)](https://github.com/stefanobaghino/sublime-mcp/actions/workflows/harness-smoke.yml)
 
 A [Sublime Text](https://www.sublimetext.com/) plugin that is also an
-[MCP](https://modelcontextprotocol.io/) server. It exposes ST's Python API
-to AI agents so they can query scopes, run syntax tests, reload syntax
-files, and more — without a human in the loop copy-pasting build-panel
-output.
+[MCP](https://modelcontextprotocol.io/) server, plus a stdio harness
+that runs both inside Docker so an agent can drive ST without a human
+in the loop.
 
-Single file, standard library only, loopback only.
+The plugin file is single-file and standard-library only. The harness
+is single-file and standard-library only. ST runs in a container with
+Xvfb; the plugin's HTTP server stays on loopback inside the container,
+and the harness proxies MCP between the agent (over stdio) and the
+plugin (over HTTP).
 
 ## Why
 
-Sublime Text's sublime-syntax engine is the ground truth for scopes. When
-a downstream consumer (e.g. [syntect](https://github.com/trishume/syntect))
-disagrees with ST, you almost always want ST's answer, not the other way
-around. Verifying "what does ST say" manually — symlink the package, open
-ST, run **Tools → Build With → Syntax Tests**, copy the output panel —
-is slow and error-prone.
+Sublime Text's sublime-syntax engine is the ground truth for scopes.
+When a downstream consumer (e.g. [syntect](https://github.com/trishume/syntect))
+disagrees with ST, you almost always want ST's answer. Verifying "what
+does ST say" manually — symlink the package, open ST, run **Tools →
+Build With → Syntax Tests**, copy the output panel — is slow and
+error-prone, and doesn't fit autonomous agent workflows at all.
 
-This plugin runs inside ST's plugin host and serves a single MCP tool,
-`exec_sublime_python`, that runs arbitrary Python inside ST's process. An
-agent with this tool can script the checks that would otherwise need a
-human.
+The plugin runs inside ST's plugin host and serves a single MCP tool,
+`exec_sublime_python`, which runs arbitrary Python inside ST. The
+harness packages all of that — ST, Xvfb, the plugin — into a Docker
+container and exposes it as a stdio MCP server an agent can register
+directly.
 
 ## Requirements
 
-- Sublime Text 4 (Python 3.8 plugin host).
-- macOS paths below — trivial to port, but only Darwin is tested.
+- Docker (Engine or Desktop), with the daemon running.
+- Python 3.10+ on the host (for the harness).
+- A [Sublime Text](https://www.sublimetext.com/) license is
+  recommended but not required — ST runs in evaluation mode by default
+  inside the container.
 
 ## Install
 
 ```sh
-git clone https://github.com/stefanobaghino/sublime-mcp \
-  ~/Projects/github.com/stefanobaghino/sublime-mcp
-
-ln -s ~/Projects/github.com/stefanobaghino/sublime-mcp/sublime_mcp.py \
-      "$HOME/Library/Application Support/Sublime Text/Packages/User/sublime_mcp.py"
+git clone https://github.com/stefanobaghino/sublime-mcp
+cd sublime-mcp
+pipx install -e .
 ```
 
-Open ST (or save any `.py` file under `Packages/User/`) to trigger
-`plugin_loaded()`. Open the console (**View → Show Console**) and look for:
+`pipx install -e .` keeps `sublime-mcp` pointing at this checkout
+(the harness reads the bundled `Dockerfile`, `docker/entrypoint.sh`,
+and `sublime_mcp.py` from `Path(__file__).parent`). Plain
+`pip install -e .` works too if you already have a managed environment.
 
-```
-[sublime-mcp] listening on 127.0.0.1:47823
-```
-
-## Configure Claude Code
+## Register with Claude Code
 
 ```sh
-claude mcp add --transport http --scope user \
-  sublime-text http://127.0.0.1:47823/mcp
+claude mcp add --scope user --transport stdio sublime-text -- \
+    sublime-mcp --mount "$PWD:/work"
 ```
 
-Or add directly to `~/.claude.json`:
+The name `sublime-text` is load-bearing: the bundled skill's
+`allowed-tools` hard-codes `mcp__sublime-text__exec_sublime_python`.
+Registered under a different name, the skill won't see the tool.
 
-```json
-{
-  "mcpServers": {
-    "sublime-text": {
-      "type": "http",
-      "url": "http://127.0.0.1:47823/mcp"
-    }
-  }
-}
-```
+`--mount $PWD:/work` makes your working tree visible to ST inside the
+container. Repeat the flag for additional paths. Without a mount, paths
+you'd pass into `exec_sublime_python` calls won't resolve.
+
+The first connection triggers `docker build`; expect a few minutes the
+first time. Subsequent connections boot the container in a few seconds.
 
 ## Install the skill (optional, Claude Code only)
 
@@ -79,75 +81,100 @@ Install by symlinking it into the user-scope skills directory:
 ln -s "$PWD/skills/sublime-mcp" ~/.claude/skills/sublime-mcp
 ```
 
-Or `cp -R skills/sublime-mcp ~/.claude/skills/sublime-mcp` if symlinks misbehave on your platform.
+Or `cp -R skills/sublime-mcp ~/.claude/skills/sublime-mcp` if symlinks
+misbehave on your platform.
 
 ## Verify
 
-```sh
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
-       "params":{"name":"exec_sublime_python",
-                 "arguments":{"code":"print(sublime.version())"}}}'
+In a Claude Code session that has the skill loaded:
+
+```
+mcp__sublime-text__exec_sublime_python({ code: "print(sublime.version())" })
 ```
 
-Should return ST's build number in the `output` field.
+Returns ST's build number in `output`. From a shell, the equivalent is
+`tests/test_harness_smoke.py` — boots the harness, sends the same call,
+asserts the round-trip.
 
-The tool's own `description` (readable via `tools/list`) is a cookbook of
-common recipes — scope-at, run syntax tests, reload a syntax file, list
-resources. Agents should read it as their primary reference.
+The tool's own `description` (readable via `tools/list`) is a cookbook
+of common recipes — scope-at, run syntax tests, reload a syntax file,
+list resources. Agents should read it as their primary reference.
+
+## Harness flags
+
+```
+sublime-mcp [--mount HOST:CONTAINER] [--image-tag TAG]
+            [--rebuild] [--license-file PATH]
+```
+
+- `--mount HOST:CONTAINER` (repeatable): bind-mount HOST into the
+  container at CONTAINER. Recommended: `--mount $PWD:/work`.
+- `--image-tag TAG`: override the image tag (default
+  `sublime-mcp-harness:latest`).
+- `--rebuild`: force `docker build` even if the image already exists.
+- `--license-file PATH`: mount a Sublime Text license file into the
+  container's `~/.config/sublime-text/Local/`.
+
+## Multi-agent
+
+Each agent session spawns its own harness; each harness owns its own
+container. Host ports are kernel-assigned, so concurrent agents on the
+same machine don't collide. `docker ps --filter
+label=sublime-mcp-harness` lists the running containers; the label
+value is the harness's PID.
 
 ## Tests
 
-Two suites, both running inside Sublime Text via the
-[UnitTesting](https://github.com/SublimeText/UnitTesting) package:
+Three surfaces, all in CI:
 
-- [`tests/test_smoke.py`](tests/test_smoke.py) pings the MCP endpoint
-  over loopback and confirms `initialize` round-trips.
-- [`tests/test_helpers.py`](tests/test_helpers.py) covers the helper
-  surface exposed inside `exec_sublime_python`: response shape (outer
-  `ok` dropped, `error` populated on exception), `scope_at` vs
-  `scope_at_test` on extension-less files, `resolve_position`'s
-  overflow / clamped matrix, `run_syntax_tests` via
-  `sublime_api.run_syntax_test` (and its outside-Packages raise), and
-  `_to_resource_path` edge cases.
+- [`tests/test_smoke.py`](tests/test_smoke.py) and
+  [`tests/test_helpers.py`](tests/test_helpers.py) — plugin-level tests
+  running inside Sublime Text via the
+  [UnitTesting](https://github.com/SublimeText/UnitTesting) package
+  ([`tests.yml`](.github/workflows/tests.yml)). They cover the helper
+  surface in isolation against a host ST.
+- [`tests/headless_smoke.py`](tests/headless_smoke.py) — pins
+  `open_view`'s headless guard against a real ST instance with no
+  windows ([`headless.yml`](.github/workflows/headless.yml), macOS).
+- [`tests/test_harness_smoke.py`](tests/test_harness_smoke.py) — boots
+  the harness end-to-end against Docker, drives `initialize` +
+  `tools/call exec_sublime_python` over stdio
+  ([`harness-smoke.yml`](.github/workflows/harness-smoke.yml), Linux).
 
-### Locally
-
-UnitTesting discovers `tests/` at the package root, so the repo needs to
-be installed as its own package (rather than the single-file `Packages/User`
-symlink from [Install](#install)):
-
-```sh
-ln -s ~/Projects/github.com/stefanobaghino/sublime-mcp \
-      "$HOME/Library/Application Support/Sublime Text/Packages/sublime-mcp"
-```
-
-Remove the `Packages/User/sublime_mcp.py` symlink first if you have one —
-two copies would fight for port 47823.
-
-Install the **UnitTesting** package via Package Control, then run
-**UnitTesting: Test Current Package** from the Command Palette with any
-file from the repo active. Expected: `1 test … OK`.
-
-### CI
-
-[`.github/workflows/tests.yml`](.github/workflows/tests.yml) runs the
-suite on `ubuntu-latest` and `macOS-latest` via
-[`SublimeText/UnitTesting/actions`](https://github.com/SublimeText/UnitTesting)
-for every push and pull request.
+The host-ST surface (`tests.yml`, `headless.yml`) covers plugin
+correctness in isolation; the harness surface covers the user-facing
+path. Both are gated on PR.
 
 ## Security
 
-- Binds `127.0.0.1` only. Not reachable off the local machine.
-- Runs arbitrary Python inside Sublime Text. That is the feature — but it
-  means anyone with local network access to the loopback port has full
-  control of your editor. Do not expose the port beyond localhost and do
-  not run this plugin on a multi-user machine you don't trust.
+- The plugin's HTTP server binds `127.0.0.1` *inside the container*,
+  not on the host. The harness's port mapping uses `-p 127.0.0.1:0:…`
+  so the host port is also loopback-only.
+- Anyone with shell access to your machine can connect to the
+  container's host port and run arbitrary Python in the ST instance —
+  same blast radius as having ST open and a debugger attached.
+- The container runs as root inside its own namespace; the harness
+  passes through volumes you explicitly mount with `--mount`.
+
+## Contributor: running the plugin against host ST
+
+Useful for plugin-level work where booting Docker per change is
+overkill. The host-ST install path:
+
+```sh
+ln -s "$PWD/sublime_mcp.py" \
+      "$HOME/Library/Application Support/Sublime Text/Packages/User/sublime_mcp.py"
+```
+
+Open ST and look for `[sublime-mcp] listening on 127.0.0.1:47823` in
+the console. The host-ST CI workflows (`tests.yml`, `headless.yml`) use
+this layout. Users should not register this directly with Claude Code;
+the harness is the supported user path.
 
 ## Uninstall
 
 ```sh
-rm "$HOME/Library/Application Support/Sublime Text/Packages/User/sublime_mcp.py"
 claude mcp remove sublime-text --scope user
+pipx uninstall sublime-mcp-harness
+docker image rm sublime-mcp-harness:latest
 ```

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Boot Xvfb, launch Sublime Text against the workspace, and stay alive
+# until the container is stopped. The plugin_loaded() hook in
+# sublime_mcp.py binds 127.0.0.1:47823 once ST starts.
+#
+# ST self-daemonizes (re-execs as `--detached`) and the launching
+# `subl` wrapper exits as soon as the daemon is up. So we cannot
+# `wait` on the launcher PID to keep PID 1 alive — instead we hold
+# PID 1 with a trap-friendly sleep loop. `docker stop` sends SIGTERM
+# to PID 1; the trap fires, ST and Xvfb get SIGTERM, and the
+# container exits.
+
+set -eu
+
+# Pick a workspace path that exists. The harness recommends
+# `--mount $PWD:/work`; if the caller skipped it, fall back to /tmp so
+# `subl --stay <path>` opens a window (the plugin's open_view guard
+# requires len(sublime.windows()) > 0).
+if [ -d /work ]; then
+    WORKSPACE=/work
+else
+    WORKSPACE=/tmp
+fi
+
+# Xvfb on :1, matching DISPLAY in the Dockerfile.
+Xvfb :1 -screen 0 1024x768x24 -nolisten tcp >/var/log/xvfb.log 2>&1 &
+
+# Give Xvfb a moment to create the socket before ST tries to connect.
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if [ -S /tmp/.X11-unix/X1 ]; then break; fi
+    sleep 0.1
+done
+
+# `subl` is a thin wrapper around `sublime_text --fwdargv0`. ST then
+# re-execs as `--detached --stay <workspace>` and the wrapper exits.
+# Run it synchronously — control returns once ST is daemonized and
+# our work is to keep PID 1 alive afterwards.
+#
+# The plugin reads SUBLIME_MCP_HOST at module import time. Bind on
+# 0.0.0.0 so Docker Desktop's userland port-forwarder (which connects
+# from the bridge IP, not loopback) can reach the server. Host-side
+# exposure is still loopback-only via `-p 127.0.0.1:0:47823`.
+export SUBLIME_MCP_HOST=0.0.0.0
+subl --stay "$WORKSPACE"
+
+# Forward SIGTERM/SIGINT to ST + Xvfb so `docker stop` is clean.
+# `pkill -f sublime_text` matches both the daemon and the plugin
+# hosts; `pkill Xvfb` covers the display.
+cleanup() {
+    pkill -TERM -f sublime_text 2>/dev/null || true
+    pkill -TERM Xvfb 2>/dev/null || true
+}
+trap 'cleanup; exit 0' TERM INT
+
+# Hold PID 1 forever, in a way that lets the trap fire on signals.
+# `wait` on a backgrounded sleep returns when SIGTERM interrupts it.
+while :; do
+    sleep 3600 &
+    wait $!
+done

--- a/harness.py
+++ b/harness.py
@@ -1,0 +1,478 @@
+"""Stdio MCP harness that runs sublime-mcp inside a Docker container.
+
+The harness is the user-facing entrypoint of sublime-mcp: an agent
+registers it as a stdio MCP server (`claude mcp add --transport stdio
+sublime-text -- sublime-mcp …`), and the harness boots a container with
+Sublime Text + the plugin, waits for the in-container HTTP server to
+come up, and proxies JSON-RPC messages between the agent (over stdio)
+and the plugin (over HTTP).
+
+One harness owns one container; one agent's session spawns one harness.
+Multiple agents on the same machine each get their own harness +
+container — host ports are kernel-assigned, so no coordination is
+needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import queue
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_IMAGE_TAG = "sublime-mcp-harness:latest"
+CONTAINER_PORT = 47823
+CONTAINER_LICENSE_DIR = "/root/.config/sublime-text/Local"
+READINESS_TIMEOUT_S = 60.0
+SHUTDOWN_GRACE_S = 1.0
+PROXY_HTTP_TIMEOUT_S = 70.0  # exec snippets cap at 60s server-side
+
+
+def log(msg: str) -> None:
+    """Print to stderr — stdout is the MCP transport."""
+    print("[sublime-mcp-harness] %s" % msg, file=sys.stderr, flush=True)
+
+
+# ---------------------------------------------------------------------
+# Argument parsing
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="sublime-mcp",
+        description="Stdio MCP harness for sublime-mcp inside Docker.",
+    )
+    parser.add_argument(
+        "--mount",
+        action="append",
+        default=[],
+        metavar="HOST:CONTAINER",
+        help="Bind-mount HOST into the container at CONTAINER. Repeatable. "
+             "Recommended: --mount $PWD:/work",
+    )
+    parser.add_argument(
+        "--image-tag",
+        default=DEFAULT_IMAGE_TAG,
+        help="Image tag to look up / build. Default: %(default)s",
+    )
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Force `docker build` even if the image already exists.",
+    )
+    parser.add_argument(
+        "--license-file",
+        metavar="PATH",
+        help="Mount a Sublime Text license file into the container.",
+    )
+    args = parser.parse_args(argv)
+    for spec in args.mount:
+        if ":" not in spec or spec.startswith(":") or spec.endswith(":"):
+            parser.error("--mount expects HOST:CONTAINER, got %r" % spec)
+    if args.license_file and not Path(args.license_file).is_file():
+        parser.error("--license-file %r is not a regular file" % args.license_file)
+    return args
+
+
+# ---------------------------------------------------------------------
+# Build context
+
+
+def build_context_dir() -> Path:
+    """Locate the Dockerfile + sublime_mcp.py + entrypoint.sh.
+
+    Two cases: running from a source checkout (next to harness.py) or
+    installed as a package (alongside the module). In both cases the
+    files sit next to this file.
+    """
+    here = Path(__file__).resolve().parent
+    required = ["Dockerfile", "sublime_mcp.py", "docker/entrypoint.sh"]
+    missing = [name for name in required if not (here / name).is_file()]
+    if missing:
+        raise RuntimeError(
+            "build context incomplete next to %s: missing %s"
+            % (here, ", ".join(missing))
+        )
+    return here
+
+
+def stage_build_context(src: Path) -> Path:
+    """Copy the build context into a temp dir for `docker build`.
+
+    Avoids passing the source directory directly so transient files
+    (e.g. .pyc, editor swap files) don't get pulled into the image.
+    """
+    dst = Path(tempfile.mkdtemp(prefix="sublime-mcp-harness-build-"))
+    shutil.copy2(src / "Dockerfile", dst / "Dockerfile")
+    shutil.copy2(src / "sublime_mcp.py", dst / "sublime_mcp.py")
+    (dst / "docker").mkdir()
+    shutil.copy2(src / "docker" / "entrypoint.sh", dst / "docker" / "entrypoint.sh")
+    return dst
+
+
+# ---------------------------------------------------------------------
+# Docker calls
+
+
+def docker_available() -> tuple[bool, str]:
+    """Check that `docker` is on PATH and the daemon is reachable.
+
+    Returns (ok, reason). `reason` is empty when ok.
+    """
+    try:
+        subprocess.run(
+            ["docker", "--version"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return False, "`docker` not found on PATH"
+    except subprocess.CalledProcessError:
+        return False, "`docker --version` failed"
+    result = subprocess.run(
+        ["docker", "info"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        msg = (result.stderr or b"").decode("utf-8", "replace").strip().splitlines()
+        tail = msg[-1] if msg else "(no stderr)"
+        return False, "docker daemon unreachable (%s)" % tail
+    return True, ""
+
+
+def image_exists(tag: str) -> bool:
+    result = subprocess.run(
+        ["docker", "image", "inspect", tag],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def build_image(tag: str, context: Path) -> None:
+    log("building image %s (this can take a few minutes on first run)…" % tag)
+    subprocess.run(
+        ["docker", "build", "-t", tag, str(context)],
+        check=True,
+    )
+    log("image %s built" % tag)
+
+
+def ensure_image(tag: str, force: bool, context: Path) -> None:
+    """Build the image with a host-side flock so concurrent first-runs serialise."""
+    cache_dir = Path.home() / ".cache" / "sublime-mcp-harness"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = cache_dir / "build.lock"
+    with open(lock_path, "w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        # Re-check inside the lock — another harness might have just
+        # finished building.
+        if force or not image_exists(tag):
+            staged = stage_build_context(context)
+            try:
+                build_image(tag, staged)
+            finally:
+                shutil.rmtree(staged, ignore_errors=True)
+        else:
+            log("reusing image %s" % tag)
+
+
+def run_container(
+    tag: str,
+    mounts: list[str],
+    license_file: str | None,
+) -> str:
+    args = [
+        "docker", "run",
+        "-d",
+        "--rm",
+        "--label", "sublime-mcp-harness=%d" % os.getpid(),
+        "-p", "127.0.0.1:0:%d" % CONTAINER_PORT,
+    ]
+    for spec in mounts:
+        args += ["-v", spec]
+    if license_file:
+        args += [
+            "-v",
+            "%s:%s/License.sublime_license:ro"
+            % (str(Path(license_file).resolve()), CONTAINER_LICENSE_DIR),
+        ]
+    args.append(tag)
+    result = subprocess.run(args, check=True, capture_output=True, text=True)
+    cid = result.stdout.strip()
+    if not cid:
+        raise RuntimeError("docker run produced no container id")
+    return cid
+
+
+def host_port(cid: str) -> int:
+    result = subprocess.run(
+        ["docker", "port", cid, "%d/tcp" % CONTAINER_PORT],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    # Lines look like `127.0.0.1:54321` — take the first IPv4 mapping.
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line or line.startswith("[::]"):
+            continue
+        host, _, port = line.rpartition(":")
+        if host and port.isdigit():
+            return int(port)
+    raise RuntimeError("docker port returned no IPv4 mapping: %r" % result.stdout)
+
+
+def stop_container(cid: str) -> None:
+    """Stop the container with a short grace, then kill if it lingers."""
+    try:
+        subprocess.run(
+            ["docker", "stop", "--time", str(int(SHUTDOWN_GRACE_S)), cid],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=SHUTDOWN_GRACE_S + 5.0,
+        )
+    except subprocess.TimeoutExpired:
+        pass
+    # `docker stop` returning doesn't guarantee the container is gone
+    # if it ignored SIGTERM; force-kill to be sure.
+    subprocess.run(
+        ["docker", "kill", cid],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------
+# In-container MCP HTTP client
+
+
+def http_post(url: str, payload: bytes, timeout: float) -> tuple[int, bytes]:
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.getcode(), resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def wait_for_ready(port: int, deadline: float) -> None:
+    """Poll the in-container MCP endpoint until it answers ping."""
+    url = "http://127.0.0.1:%d/mcp" % port
+    payload = json.dumps({"jsonrpc": "2.0", "id": "harness-ping", "method": "ping"}).encode("utf-8")
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            status, _ = http_post(url, payload, timeout=2.0)
+            if status == 200:
+                return
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_err = exc
+        time.sleep(0.5)
+    raise RuntimeError(
+        "in-container MCP server did not respond within %.0fs: %r"
+        % (READINESS_TIMEOUT_S, last_err)
+    )
+
+
+def wait_for_window(port: int, deadline: float) -> None:
+    """Verify ST has at least one window open before declaring ready.
+
+    Protects against the headless guard at sublime_mcp.py:442-450
+    surprising the first agent call.
+    """
+    url = "http://127.0.0.1:%d/mcp" % port
+    body = {
+        "jsonrpc": "2.0",
+        "id": "harness-windows",
+        "method": "tools/call",
+        "params": {
+            "name": "exec_sublime_python",
+            "arguments": {"code": "print(len(sublime.windows()))"},
+        },
+    }
+    payload = json.dumps(body).encode("utf-8")
+    last_state = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            status, raw = http_post(url, payload, timeout=5.0)
+            if status == 200:
+                resp = json.loads(raw.decode("utf-8"))
+                content = resp.get("result", {}).get("content") or []
+                if content and content[0].get("type") == "text":
+                    outcome = json.loads(content[0]["text"])
+                    output = (outcome.get("output") or "").strip()
+                    last_state = "output=%r error=%r" % (output, outcome.get("error"))
+                    if output.isdigit() and int(output) >= 1:
+                        return
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            last_state = repr(exc)
+        time.sleep(0.5)
+    raise RuntimeError(
+        "Sublime Text never opened a window (last state: %s). "
+        "The container's entrypoint should have run `subl --stay /work`; "
+        "check `docker logs` for Xvfb or licensing errors." % last_state
+    )
+
+
+# ---------------------------------------------------------------------
+# Stdio proxy
+
+
+_EOF = object()
+
+
+def _stdin_reader(q: queue.Queue) -> None:
+    """Push each stdin line onto `q`, then `_EOF` when stdin closes.
+
+    Runs as a daemon thread so the main thread can observe a stop
+    signal between queue polls — a blocking readline() on the main
+    thread would not notice SIGTERM until the next byte arrives.
+    """
+    stdin = sys.stdin.buffer
+    while True:
+        line = stdin.readline()
+        if not line:
+            q.put(_EOF)
+            return
+        q.put(line)
+
+
+def proxy_loop(port: int, stop_event: threading.Event) -> None:
+    """Forward newline-delimited JSON-RPC between stdin/stdout and the container."""
+    url = "http://127.0.0.1:%d/mcp" % port
+    stdout = sys.stdout.buffer
+    q: queue.Queue = queue.Queue()
+    reader = threading.Thread(target=_stdin_reader, args=(q,), daemon=True)
+    reader.start()
+    while not stop_event.is_set():
+        try:
+            item = q.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        if item is _EOF:
+            return
+        stripped = item.strip()
+        if not stripped:
+            continue
+        try:
+            status, raw = http_post(url, stripped, timeout=PROXY_HTTP_TIMEOUT_S)
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
+            err = _make_error_response(stripped, "container HTTP error: %r" % exc)
+            stdout.write(err + b"\n")
+            stdout.flush()
+            continue
+        if status == 202 or not raw:
+            # Notification → no body, no stdout write.
+            continue
+        if status != 200:
+            err = _make_error_response(
+                stripped,
+                "container returned HTTP %d: %s" % (status, raw[:200].decode("utf-8", "replace")),
+            )
+            stdout.write(err + b"\n")
+            stdout.flush()
+            continue
+        # Pass through verbatim. The plugin already speaks MCP JSON-RPC.
+        stdout.write(raw)
+        if not raw.endswith(b"\n"):
+            stdout.write(b"\n")
+        stdout.flush()
+
+
+def _make_error_response(request_bytes: bytes, message: str) -> bytes:
+    """Synthesise a JSON-RPC error response keyed to the request's id."""
+    req_id = None
+    try:
+        req = json.loads(request_bytes.decode("utf-8"))
+        if isinstance(req, dict):
+            req_id = req.get("id")
+    except (ValueError, UnicodeDecodeError):
+        pass
+    body = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": -32603, "message": message},
+    }
+    return json.dumps(body).encode("utf-8")
+
+
+# ---------------------------------------------------------------------
+# Top-level
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(list(sys.argv[1:] if argv is None else argv))
+
+    ok, reason = docker_available()
+    if not ok:
+        log("ERROR: %s. Install Docker Desktop or the Docker Engine, "
+            "ensure the daemon is running, and retry." % reason)
+        return 2
+
+    try:
+        ctx = build_context_dir()
+    except RuntimeError as exc:
+        log("ERROR: %s" % exc)
+        return 2
+
+    try:
+        ensure_image(args.image_tag, args.rebuild, ctx)
+    except subprocess.CalledProcessError as exc:
+        log("ERROR: docker build failed (exit %d)" % exc.returncode)
+        return exc.returncode or 1
+
+    try:
+        cid = run_container(args.image_tag, args.mount, args.license_file)
+    except subprocess.CalledProcessError as exc:
+        log("ERROR: docker run failed (exit %d): %s" % (exc.returncode, exc.stderr or ""))
+        return exc.returncode or 1
+
+    stop_event = threading.Event()
+
+    def shutdown(signum: int | None = None, frame: object | None = None) -> None:
+        stop_event.set()
+
+    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, shutdown)
+
+    try:
+        port = host_port(cid)
+        deadline = time.monotonic() + READINESS_TIMEOUT_S
+        wait_for_ready(port, deadline)
+        wait_for_window(port, deadline)
+        log("ready on 127.0.0.1:%d (container %s)" % (port, cid[:12]))
+        proxy_loop(port, stop_event)
+        return 0
+    except Exception as exc:
+        log("ERROR: %s" % exc)
+        return 1
+    finally:
+        try:
+            stop_container(cid)
+        except Exception as exc:
+            log("warning: cleanup of container %s failed: %r" % (cid[:12], exc))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sublime-mcp-harness"
+version = "0.1.0"
+description = "Stdio MCP harness that runs sublime-mcp inside a Docker container."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Stefano Baghino" },
+]
+classifiers = [
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development",
+]
+# stdlib-only at runtime; docker is a system dependency, not a Python one.
+dependencies = []
+
+[project.scripts]
+sublime-mcp = "harness:main"
+
+[project.urls]
+Homepage = "https://github.com/stefanobaghino/sublime-mcp"
+Issues = "https://github.com/stefanobaghino/sublime-mcp/issues"
+
+[tool.setuptools]
+# v1 ships as an editable install from a source checkout (`pipx install
+# -e .`). The harness reads Dockerfile, docker/entrypoint.sh, and
+# sublime_mcp.py from `Path(__file__).parent`, so the source layout is
+# what gets used at runtime. A proper package layout for non-editable
+# wheels can come when PyPI distribution becomes a goal.
+py-modules = ["harness"]

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -16,7 +16,9 @@ allowed-tools: Bash, Read, Grep, Glob, mcp__sublime-text__exec_sublime_python
 
 # Sublime Text ground-truth via MCP
 
-This skill drives the `sublime-mcp` server to get authoritative answers from Sublime Text itself — what scope it assigns at a point, which `.sublime-syntax` it resolved, whether an assertion file passes ST's built-in runner — via one tool, `exec_sublime_python`, which runs Python inside ST's plugin host. The server answers at `127.0.0.1:47823` while ST is open with the plugin loaded.
+This skill drives the `sublime-mcp` server to get authoritative answers from Sublime Text itself — what scope it assigns at a point, which `.sublime-syntax` it resolved, whether an assertion file passes ST's built-in runner — via one tool, `exec_sublime_python`, which runs Python inside ST's plugin host.
+
+**Transport.** The server is a stdio MCP harness (`sublime-mcp`) that runs Sublime Text inside a Docker container. The agent's session spawns one harness process; the harness owns one container; the container runs ST + the plugin and is reclaimed when the harness exits. The agent never sees Docker — only the `mcp__sublime-text__exec_sublime_python` tool.
 
 ## 1. Preflight — check before driving the tool
 
@@ -26,15 +28,18 @@ If it's missing, diagnose with:
 
 ```bash
 claude mcp list | grep sublime-text
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"print(len(sublime.windows()))"}}}'
+docker ps --filter label=sublime-mcp-harness --format '{{.ID}} {{.Status}}'
 ```
 
-Expected: `claude mcp list` shows `sublime-text ✓ Connected`; the second call returns a JSON-RPC `result` with a `protocolVersion`; the third call's `output` is `"1\n"` or higher. If `claude mcp list` or the second call fails, point the user at `install.md` in this skill's directory. If the third call's `output` is `"0\n"`, ST's plugin host is running but headless — ask the user to open an ST window (`open -a "Sublime Text"` on macOS) before proceeding; helpers that drive views (`open_view`, `scope_at`, `scope_at_test`, `resolve_position`) raise `RuntimeError` in this state. Do not attempt to fall back to manual ST UI inspection without first telling the user the skill cannot run.
+Expected: `claude mcp list` shows `sublime-text ✓ Connected`; `docker ps` shows one running container per active agent session. If the registration is missing or shows ✗, point the user at `install.md` in this skill's directory. If the registration is healthy but the container is missing, the harness is failing to boot — read its stderr (Claude Code surfaces it in the MCP log; on the user's side, `claude mcp logs sublime-text` if available, otherwise the harness's stderr stream during connection).
+
+Common boot-time failures the harness signals on stderr (`[sublime-mcp-harness] ERROR: …`):
+
+- `docker not found on PATH` — install Docker and ensure the daemon is running.
+- `Sublime Text never opened a window` — Xvfb or licensing issue inside the container; check `docker logs <cid>`.
+- `docker build failed` — image build broke; re-run with `--rebuild` after fixing.
+
+Do not attempt to fall back to manual ST UI inspection without first telling the user the skill cannot run.
 
 ## 2. Decide whether this skill is the right call
 
@@ -48,7 +53,7 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 
 ## 3. The one tool and its contract
 
-`mcp__sublime-text__exec_sublime_python({ code })` runs `code` on a dedicated daemon thread inside ST's plugin host (Python 3.8) and returns:
+`mcp__sublime-text__exec_sublime_python({ code })` runs `code` on a dedicated daemon thread inside the containerised ST's plugin host (Python 3.8) and returns:
 
 ```json
 { "output": "<captured print()>", "result": "<repr(_) or null>", "error": "<traceback or null>", "st_version": 4200, "st_channel": "stable", "isError": false }
@@ -62,14 +67,16 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
 
+**Paths are container-side.** Every path you pass into `exec_sublime_python` (to `scope_at`, `run_syntax_tests`, etc.) is resolved inside the container, not on the host. The user mounts host directories into the container at registration time; the recommended mount is `--mount $PWD:/work` so a host `~/Projects/foo/syntax_test_x.cs` becomes `/work/foo/syntax_test_x.cs` in calls. If a path you'd expect to resolve raises `FileNotFoundError`, check the user's mount before retrying; ask them rather than guessing the host-to-container mapping.
+
 ## 4. Recipes
 
-Each recipe is one `exec_sublime_python` call. Rows and columns are **0-indexed** — a test-file assertion on line 181 col 9 is `row=180, col=8`.
+Each recipe is one `exec_sublime_python` call. Rows and columns are **0-indexed** — a test-file assertion on line 181 col 9 is `row=180, col=8`. Paths shown are container-side; the user typically mounts their working tree at `/work`.
 
 ### Scope at a position
 
 ```python
-r = scope_at("/path/to/Packages/C#/tests/syntax_test_Generics.cs", 180, 8)
+r = scope_at("/work/Packages/C#/tests/syntax_test_Generics.cs", 180, 8)
 print(r["scope"], "via", r["resolved_syntax"])
 ```
 
@@ -78,21 +85,21 @@ print(r["scope"], "via", r["resolved_syntax"])
 **Landmine: extension-less syntax-test files** (`syntax_test_git_config`, no suffix) silently fall back to Plain Text via `scope_at` — `scope == "text.plain"` and `resolved_syntax == "Packages/Text/Plain text.tmLanguage"`. Use `scope_at_test` — it parses the `# SYNTAX TEST "Packages/..."` header and assigns that syntax before sampling.
 
 ```python
-r = scope_at_test("/path/to/syntax_test_git_config", 71, 28)
+r = scope_at_test("/work/syntax_test_git_config", 71, 28)
 print(r["scope"])
 ```
 
 The header parser is comment-token-agnostic — it accepts `#`, `//`, `<!--`, `;`, `--`, `|`, etc. Markdown's pipe-comment header works the same way:
 
 ```python
-r = scope_at_test("/path/to/syntax_test_markdown.md", 12, 4)
+r = scope_at_test("/work/syntax_test_markdown.md", 12, 4)
 print(r["scope"])
 ```
 
 ### Run syntax tests against a file
 
 ```python
-r = run_syntax_tests("/path/to/Packages/C#/tests/syntax_test_Generics.cs")
+r = run_syntax_tests("/work/Packages/C#/tests/syntax_test_Generics.cs")
 print(r["summary"])
 for msg in r["failures"]:
     print(msg)
@@ -129,14 +136,14 @@ Same `{state, summary, output, failures}` shape as `run_syntax_tests`, with one 
 
 `view.assign_syntax` takes a `Packages/...` resource URI, not an arbitrary filesystem path. The older `view.set_syntax_file` has the same constraint but fails silently when given a filesystem path: `view.settings().get("syntax")` echoes the assigned absolute path, ST surfaces a "file not found" popup, `view.scope_name(...)` returns `text.plain` for every position, and the Python call doesn't raise. Prefer `assign_syntax_and_wait`.
 
-For a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy), use `temp_packages_link` to manage a per-call symlink. The helper synthesises `Packages/__sublime_mcp_temp_<nonce>__`, waits for ST's resource indexer to surface the sentinel, and returns the synthesised package name. Pass the syntax's filesystem path directly to `resolve_position` / `assign_syntax_and_wait` — the helpers reverse-map filesystem inputs through any symlink in `sublime.packages_path()` to the matching `Packages/...` URI. (Constructing the URI by hand as `"Packages/%s/Java.sublime-syntax" % name` still works.) The caller tears down via `release_packages_link`.
+For a syntax file that lives outside ST's Packages tree (e.g. a syntect `testdata/Packages/...` copy mounted at `/work/testdata/...`), use `temp_packages_link` to manage a per-call symlink. The helper synthesises `Packages/__sublime_mcp_temp_<nonce>__`, waits for ST's resource indexer to surface the sentinel, and returns the synthesised package name. Pass the syntax's filesystem path directly to `resolve_position` / `assign_syntax_and_wait` — the helpers reverse-map filesystem inputs through any symlink in `sublime.packages_path()` to the matching `Packages/...` URI. (Constructing the URI by hand as `"Packages/%s/Java.sublime-syntax" % name` still works.) The caller tears down via `release_packages_link`.
 
 ```python
-syntax_path = "/path/to/repo/testdata/Packages/Java/Java.sublime-syntax"
+syntax_path = "/work/testdata/Packages/Java/Java.sublime-syntax"
 name = temp_packages_link(syntax_path)
 try:
     r = resolve_position(
-        "/path/to/syntax_test_file", row=71, col=29,
+        "/work/syntax_test_file", row=71, col=29,
         syntax_path=syntax_path,
     )
     print(r["scope"], "overflow:", r["overflow"], "clamped:", r["clamped"])
@@ -157,18 +164,18 @@ Three-step divergence triage:
 
 ```python
 # 1. What does ST report at the failing position?
-r = scope_at_test("/path/to/syntax_test_git_config", 71, 28)
+r = scope_at_test("/work/syntax_test_git_config", 71, 28)
 print(r["scope"], "via", r["resolved_syntax"])
 
 # 2. Did both engines sample the same point? (past-EOL divergence is common)
 r = resolve_position(
-    "/path/to/syntax_test_git_config", 71, 29,
+    "/work/syntax_test_git_config", 71, 29,
     syntax_path="Packages/Git Formats/Git Config.sublime-syntax",
 )
 print("overflow:", r["overflow"], "clamped:", r["clamped"], "actual:", r["actual"])
 
 # 3. Does ST's own runner agree?
-r = run_syntax_tests("/path/to/syntax_test_git_config")
+r = run_syntax_tests("/work/syntax_test_git_config")
 print(r["summary"])
 ```
 
@@ -192,7 +199,7 @@ v.set_scratch(True); v.close()
 A `view.scope_name(point)` call on an already-tokenised view costs around 150 µs (measured: 5 × 500-sample medians on a 1.2k-line Python source view, ST 4200 stable). It's also thread-safe and runs concurrent with ST's UI, so a several-hundred-row sweep in one `exec_sublime_python` call comfortably fits the 60 s per-call budget — three orders of magnitude of headroom. The cold-view cost is a one-time tokenisation pass on the first helper call against a given path.
 
 ```python
-scopes = [scope_at("/path/to/big_file", row, 0)["scope"] for row in range(3020, 3039)]
+scopes = [scope_at("/work/big_file", row, 0)["scope"] for row in range(3020, 3039)]
 _ = scopes  # returns via `result`
 ```
 
@@ -223,7 +230,7 @@ When that happens, enumerate failing positions externally and probe each one:
 ```python
 # failing_positions = [(row, col), ...] — produced separately, e.g. by
 # syntect's examples/syntest harness against the same file.
-results = [scope_at_test("/abs/path/to/syntax_test_huge", r, c) for r, c in failing_positions]
+results = [scope_at_test("/work/syntax_test_huge", r, c) for r, c in failing_positions]
 _ = results
 ```
 

--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -4,108 +4,108 @@ This file is loaded only when `SKILL.md`'s preflight check (§1) fails. The top-
 
 ## What has to be true
 
-- Sublime Text is running with `sublime_mcp.py` loaded. The ST console (**View → Show Console**) shows `[sublime-mcp] listening on 127.0.0.1:47823`.
-- Claude Code has the server registered under the name `sublime-text`:
+- **Docker is installed and the daemon is running.** `docker info` exits 0.
+- **The harness is on `PATH`.** `sublime-mcp --help` works.
+- **Claude Code has the server registered under the name `sublime-text`.**
   ```bash
   claude mcp list | grep sublime-text
   ```
   Expected: `sublime-text ✓ Connected`.
 
-## One-command smoke check
+When a Claude Code session is using the skill, `docker ps --filter label=sublime-mcp-harness` shows one running container. The harness owns the container; closing the session reclaims it.
+
+## Install the harness
+
+The harness is shipped as a single Python module + a Dockerfile, distributed via the source repo. v1 is editable-install only; the runtime needs the bundled assets to live next to the module.
 
 ```bash
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
-       "params":{"name":"exec_sublime_python",
-                 "arguments":{"code":"print(sublime.version())"}}}'
+git clone https://github.com/stefanobaghino/sublime-mcp.git
+cd sublime-mcp
+pipx install -e .
 ```
 
-Returns ST's build number in `output` on a healthy setup. Connection refused → ST isn't running the plugin. 404 → wrong endpoint path (should be `/mcp`).
+`pipx install -e` keeps `sublime-mcp` pointing at this checkout — pulling new commits picks them up; switching branches switches the harness code. Plain `pip install -e .` works too if you already have a managed environment.
 
-## If the plugin isn't loaded
-
-Re-run the symlink from [`README.md#install`](../../README.md#install) and reopen ST (or save any `.py` file under `Packages/User/`) to trigger `plugin_loaded()`. The ST console should show the listening line.
-
-## If Sublime Text has no open window
-
-ST's plugin host can run while no editor window is open (the app stays alive in the background, especially on macOS). Helpers that drive views (`open_view`, `scope_at`, `scope_at_test`, `resolve_position`) raise `RuntimeError: open_view: Sublime Text has no open window` in this state. Open one:
+## Register with Claude Code
 
 ```bash
-# macOS
-open -a "Sublime Text"
-
-# Linux: launch from your desktop entry, or invoke the binary directly
-# (often `sublime_text` or `subl` if you've set up a symlink on PATH).
-# Windows: launch via the Start menu / taskbar shortcut. There is no
-# universal CLI helper.
+claude mcp add --scope user --transport stdio sublime-text -- \
+    sublime-mcp --mount "$PWD:/work"
 ```
 
-To reproduce headlessness deliberately and verify the guard end-to-end (macOS recipe — Linux/Windows have no equivalent for AppleScript-driven window control, so verify there by quitting all windows manually instead). The scenario is also automated as `tests/headless_smoke.py`, which drives ST through MCP rather than AppleScript and so works on any platform; CI runs it on macOS via `.github/workflows/headless.yml`.
+The name `sublime-text` is load-bearing: the skill's `allowed-tools` hard-codes `mcp__sublime-text__exec_sublime_python`. Registered under a different name, the skill won't see the tool.
+
+`--mount $PWD:/work` makes the current working tree visible to ST inside the container. Repeat the flag for additional directories. **Without a `--mount`, every path you'd pass in `exec_sublime_python` calls is invisible to ST** — the skill recipes assume this mount.
+
+The first agent connection triggers `docker build`; expect a few minutes the first time. Subsequent connections boot the container in a few seconds.
+
+## Smoke check
+
+After registering, in a Claude Code session that has the skill loaded:
+
+```
+mcp__sublime-text__exec_sublime_python({ code: "print(sublime.version())" })
+```
+
+Returns ST's build number in `output` on a healthy setup. If the call errors with `FileNotFoundError` for a path under `/work`, the user forgot the `--mount`; re-register with one.
+
+## Troubleshooting
+
+### Harness fails to start
+
+The harness writes diagnostics on stderr prefixed with `[sublime-mcp-harness]`. Common cases:
+
+- `ERROR: docker not found on PATH` — install Docker (Docker Desktop on macOS/Windows, `docker-ce` package on Linux), start the daemon, retry.
+- `ERROR: docker build failed` — re-run `sublime-mcp --rebuild --mount …` to see the build output. Most often: transient apt-mirror failure; retry. If persistent, the apt repo for Sublime Text may have shifted; file an issue.
+- `ERROR: Sublime Text never opened a window (last state: …)` — the container booted but ST didn't reach a windowed state inside the readiness budget. Check `docker logs <container_id>` for Xvfb errors or licensing dialogs blocking startup.
+
+### `docker ps` shows the container but tool calls hang
+
+The plugin host inside the container is wedged. Restart the agent session (closing it triggers `docker stop`); a fresh one will spawn a new container.
+
+### Multi-agent: ports / containers
+
+Each agent session spawns its own harness, which spawns its own container. Host ports are kernel-assigned (`-p 127.0.0.1:0:47823`), so concurrent agents don't collide. `docker ps --filter label=sublime-mcp-harness` lists them — the label value is the harness's PID, useful for matching a container to a specific session.
+
+Each ST instance uses ~100–300 MB RAM. If you routinely run many concurrent agents, watch overall memory pressure.
+
+### Sublime Text license
+
+ST runs in evaluation mode by default inside the container. The plugin is unaffected; under Xvfb the nag dialog is invisible. To suppress evaluation state, pass a license:
 
 ```bash
-# Step 1. Save or discard any unsaved work — the close call below is a
-# polite per-window quit and will block on the unsaved-buffer dialog.
-# Do NOT pass `saving no` (destructive, risks data loss).
-osascript -e 'tell app "Sublime Text" to close every window'
-osascript -e 'tell app "Sublime Text" to count of windows'   # → 0
-
-# Step 2. Confirm the plugin host still sees zero windows.
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"print(len(sublime.windows()))"}}}'
-# Expected: response `output` contains "0\n".
-
-# Step 3. Trigger the guard. Any path works — the guard fires before
-# the file is read.
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"open_view(\"/tmp/anything\")"}}}'
-# Expected: response `error` contains "no open window" and "install.md".
-
-# Step 4. Recover by opening any window, then retry the original call.
-open -a "Sublime Text"
+sublime-mcp --mount "$PWD:/work" --license-file ~/path/to/License.sublime_license
 ```
+
+The file is mounted read-only into the container's `~/.config/sublime-text/Local/`.
 
 ## Verifying symlinked-package URI resolution
 
-`_to_resource_path` reverse-maps a path under a symlinked entry of `sublime.packages_path()` (e.g. `testdata/Packages/Markdown` symlinked as `~/Library/.../Packages/Markdown`) to a `Packages/<symlink_name>/...` URI that ST's resource indexer agrees on. To verify end-to-end against your real ST install:
+`_to_resource_path` reverse-maps a path under a symlinked entry of `sublime.packages_path()` to a `Packages/<symlink_name>/...` URI that ST's resource indexer agrees on. Inside the container, `sublime.packages_path()` is `/root/.config/sublime-text/Packages`. To verify end-to-end via the harness:
 
-> **Warning:** this recipe creates a symlink in your real ST Packages directory. Step 3 removes it. If you skip cleanup, ST's resource indexer keeps treating the target as a registered package across sessions until you manually `unlink` it. The recipe uses a deliberately unique symlink name (`__sublime_mcp_verify__`) so it cannot collide with any real package or shadow ST's bundled syntax handling.
-
-macOS paths shown — adjust for Linux's `~/.config/sublime-text/Packages/` or your platform's equivalent.
-
-```bash
-# Step 1. Pre-check (recovers from a prior interrupted run; -L matches
-# only symlinks, so it cannot clobber a real package), then create.
-[ -L ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__ ] && \
-  unlink ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
-ln -s /path/to/your/Packages/Markdown \
-      ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
-
-# Step 2. Call run_syntax_tests with the *target path* (outside the
-# Packages tree); the symlink-walk reverse-maps it to
-# Packages/__sublime_mcp_verify__/...
-curl -s -X POST http://127.0.0.1:47823/mcp \
-  -H 'Content-Type: application/json' \
-  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"exec_sublime_python","arguments":{"code":"r = run_syntax_tests(\"/path/to/your/Packages/Markdown/tests/syntax_test_markdown.md\"); print(r[\"summary\"])"}}}'
-# Success: `summary` is a numeric "N assertions passed" or
-# "FAILED: M of N assertions failed". Explicitly NOT a top-level
-# `error` carrying "is not under sublime.packages_path()" (the
-# symlink-walk failed to reverse-map) or "Sublime Text has not
-# indexed the resource" (mapped, but ST's resource indexer disagreed
-# with the reconstructed URI).
-
-# Step 3. Cleanup (do not skip). unlink, NOT rm -r / rm -rf — those
-# follow the symlink and would delete the target's contents.
-unlink ~/Library/Application\ Support/Sublime\ Text/Packages/__sublime_mcp_verify__
+```python
+# Inside an exec_sublime_python call:
+import os
+target = "/work/testdata/Packages/Markdown"   # mounted by the user
+link = os.path.join(sublime.packages_path(), "__sublime_mcp_verify__")
+if os.path.lexists(link):
+    os.unlink(link)
+os.symlink(target, link)
+try:
+    r = run_syntax_tests("/work/testdata/Packages/Markdown/tests/syntax_test_markdown.md")
+    print(r["summary"])
+finally:
+    os.unlink(link)
 ```
+
+Success: `summary` is a numeric "N assertions passed" or "FAILED: M of N assertions failed". A top-level `error` carrying "is not under sublime.packages_path()" means the symlink-walk failed to reverse-map.
 
 ## If Claude Code can't see the server
 
 ```bash
-claude mcp add --transport http --scope user \
-  sublime-text http://127.0.0.1:47823/mcp
+claude mcp remove sublime-text
+claude mcp add --scope user --transport stdio sublime-text -- \
+    sublime-mcp --mount "$PWD:/work"
 ```
 
 The name `sublime-text` is load-bearing: this skill's `allowed-tools` hard-codes `mcp__sublime-text__exec_sublime_python`. Registered under a different name, the skill won't see the tool.
@@ -115,5 +115,6 @@ The name `sublime-text` is load-bearing: this skill's `allowed-tools` hard-codes
 Open an issue at <https://github.com/stefanobaghino/sublime-mcp/issues> with:
 
 - `claude mcp list` output
-- The curl probe's response (stdout + stderr)
-- ST console contents from the `[sublime-mcp]` line onwards
+- `docker ps --filter label=sublime-mcp-harness` output
+- `docker logs <cid>` for the failing container (if any)
+- The harness's stderr (the `[sublime-mcp-harness]` lines)

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -13,6 +13,7 @@ import ast
 import builtins as _builtins
 import io
 import json
+import os
 import threading
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -21,8 +22,13 @@ import sublime
 import sublime_plugin  # noqa: F401  (exposed to exec'd snippets)
 
 
-HOST = "127.0.0.1"
-PORT = 47823
+# `HOST` defaults to loopback so a host install is unreachable off-box.
+# The Docker harness sets `SUBLIME_MCP_HOST=0.0.0.0` so its userland
+# port-forwarder can reach the bind from outside the container's
+# network namespace; the harness's `-p 127.0.0.1:0:47823` keeps the
+# resulting host port loopback-only.
+HOST = os.environ.get("SUBLIME_MCP_HOST", "127.0.0.1")
+PORT = int(os.environ.get("SUBLIME_MCP_PORT", "47823"))
 ENDPOINT = "/mcp"
 
 EXEC_TIMEOUT_SECONDS = 60.0

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -1,0 +1,159 @@
+"""End-to-end smoke test for the stdio harness.
+
+Spawns harness.py as a subprocess, drives it over stdin/stdout, and
+asserts the round-trip works against a real Docker container running
+Sublime Text + the plugin.
+
+Skips if `docker --version` does not work — the test is meaningless
+without Docker. CI is expected to pre-`docker build` the image so the
+first invocation here only pays container boot, not image build.
+
+Run standalone (`python3 tests/test_harness_smoke.py`) or via pytest;
+the script self-skips on either entrypoint.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HARNESS = REPO / "harness.py"
+READY_LINE = b"[sublime-mcp-harness] ready"
+READY_TIMEOUT_S = 600.0  # cold-build budget; subsequent runs are fast
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    result = subprocess.run(
+        ["docker", "info"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def _wait_ready(proc: subprocess.Popen, deadline: float) -> None:
+    """Read stderr until we see the ready marker, mirroring lines through."""
+    assert proc.stderr is not None
+    while time.monotonic() < deadline:
+        line = proc.stderr.readline()
+        if not line:
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    "harness exited before readiness (status %d)" % proc.returncode
+                )
+            time.sleep(0.05)
+            continue
+        sys.stderr.write(line.decode("utf-8", "replace"))
+        if READY_LINE in line:
+            return
+    raise RuntimeError("harness did not signal readiness within %.0fs" % READY_TIMEOUT_S)
+
+
+def _send(proc: subprocess.Popen, message: dict) -> None:
+    assert proc.stdin is not None
+    payload = (json.dumps(message) + "\n").encode("utf-8")
+    proc.stdin.write(payload)
+    proc.stdin.flush()
+
+
+def _recv(proc: subprocess.Popen, timeout_s: float) -> dict:
+    assert proc.stdout is not None
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if line:
+            return json.loads(line.decode("utf-8"))
+        if proc.poll() is not None:
+            raise RuntimeError("harness exited while awaiting response")
+        time.sleep(0.05)
+    raise RuntimeError("no response from harness within %.0fs" % timeout_s)
+
+
+def run() -> int:
+    if not _docker_available():
+        print("SKIP: docker not available", file=sys.stderr)
+        return 0
+
+    # `python -u` keeps stdout/stderr unbuffered so we see ready promptly.
+    proc = subprocess.Popen(
+        [sys.executable, "-u", str(HARNESS)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(REPO),
+    )
+    deadline = time.monotonic() + READY_TIMEOUT_S
+    try:
+        _wait_ready(proc, deadline)
+
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "harness-smoke", "version": "0"},
+            },
+        })
+        resp = _recv(proc, timeout_s=15.0)
+        assert resp.get("id") == 1, resp
+        server = resp.get("result", {}).get("serverInfo", {})
+        assert server.get("name") == "sublime-mcp", resp
+
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "exec_sublime_python",
+                "arguments": {"code": "print(sublime.version())"},
+            },
+        })
+        resp = _recv(proc, timeout_s=30.0)
+        assert resp.get("id") == 2, resp
+        content = resp.get("result", {}).get("content") or []
+        assert content and content[0].get("type") == "text", resp
+        outcome = json.loads(content[0]["text"])
+        output = (outcome.get("output") or "").strip()
+        assert output.isdigit(), outcome
+        assert int(output) >= 4000, outcome  # ST 4 build
+        print("PASS: harness round-trips, ST build %s" % output)
+        return 0
+    finally:
+        if proc.poll() is None:
+            try:
+                proc.stdin.close()  # type: ignore[union-attr]
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=10.0)
+            except subprocess.TimeoutExpired:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10.0)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    proc.wait()
+        # Drain anything left on stderr so it shows up in CI logs.
+        if proc.stderr is not None:
+            tail = proc.stderr.read()
+            if tail:
+                sys.stderr.write(tail.decode("utf-8", "replace"))
+
+
+def test_harness_round_trips() -> None:
+    assert run() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
Closes #61.

Ship a stdio MCP harness that boots Sublime Text in a Docker container and proxies MCP between the agent (over stdio) and the in-container plugin (over HTTP). One harness per agent session; multiple agents on the same machine each get their own container, with kernel-assigned host ports so they don't collide. The skill is rewritten so this is the user-facing path; the existing host-ST install survives as a contributor note for `tests.yml` / `headless.yml`.

Three Linux-specific quirks turned up during validation, all called out in the entrypoint and Dockerfile:

ST's Linux build routes the User package to its 3.3 plugin host by default. `from http.server import ThreadingHTTPServer` (3.7+) silently fails to import there, so `plugin_loaded()` is never called even though the module is imported. The image ships `Packages/User/.python-version=3.8` to opt User into the 3.8 host.

`subl` re-execs as `--detached` on Linux, so `wait $ST_PID` returns immediately and PID 1 dies with ST still running. The entrypoint now holds PID 1 with a signal-friendly sleep loop and tears ST + Xvfb down via `pkill` on SIGTERM.

Docker Desktop's userland port-forwarder cannot reach a `127.0.0.1`-only bind across the network namespace. The plugin reads `HOST` from `SUBLIME_MCP_HOST` (default `127.0.0.1`, so host installs are byte-identical), and the entrypoint sets it to `0.0.0.0`. Host-side exposure stays loopback-only via the harness's `-p 127.0.0.1:0:47823`.

## Test plan

Beyond the new `harness-smoke.yml` gate, manually verified locally (Apple Silicon, Docker Desktop):

- [x] `tests/test_harness_smoke.py` round-trips `initialize` + `tools/call exec_sublime_python` and reports ST build 4200.
- [x] Two concurrent harnesses report ready on different kernel-assigned host ports; tearing one down leaves the other responsive.
- [x] `docker ps --filter label=sublime-mcp-harness` is empty after both teardown paths (stdin EOF and SIGTERM).
- [x] `harness.py` fails fast with a clean stderr message when the daemon is unreachable (exit 2).
