### PR TITLE
Document uv as the primary install tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ directly.
 ```sh
 git clone https://github.com/stefanobaghino/sublime-mcp
 cd sublime-mcp
-pipx install -e .
+uv tool install --editable .
 ```
 
-`pipx install -e .` keeps `sublime-mcp` pointing at this checkout
-(the harness reads the bundled `Dockerfile`, `docker/entrypoint.sh`,
-and `sublime_mcp.py` from `Path(__file__).parent`). Plain
-`pip install -e .` works too if you already have a managed environment.
+`uv tool install --editable .` keeps `sublime-mcp` pointing at this
+checkout (the harness reads the bundled `Dockerfile`,
+`docker/entrypoint.sh`, and `sublime_mcp.py` from
+`Path(__file__).parent`, which an editable install resolves back to the
+source directory). `pipx install -e .` and plain `pip install -e .`
+work too if you already have one of those set up.
 
 ## Register with Claude Code
 
@@ -175,6 +177,6 @@ the harness is the supported user path.
 
 ```sh
 claude mcp remove sublime-text --scope user
-pipx uninstall sublime-mcp-harness
+uv tool uninstall sublime-mcp-harness
 docker image rm sublime-mcp-harness:latest
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,10 @@ Homepage = "https://github.com/stefanobaghino/sublime-mcp"
 Issues = "https://github.com/stefanobaghino/sublime-mcp/issues"
 
 [tool.setuptools]
-# v1 ships as an editable install from a source checkout (`pipx install
-# -e .`). The harness reads Dockerfile, docker/entrypoint.sh, and
-# sublime_mcp.py from `Path(__file__).parent`, so the source layout is
-# what gets used at runtime. A proper package layout for non-editable
-# wheels can come when PyPI distribution becomes a goal.
+# v1 ships as an editable install from a source checkout (`uv tool
+# install --editable .`). The harness reads Dockerfile,
+# docker/entrypoint.sh, and sublime_mcp.py from
+# `Path(__file__).parent`, so the source layout is what gets used at
+# runtime. A proper package layout for non-editable wheels (and `uvx`
+# from a git URL) can come when PyPI distribution becomes a goal.
 py-modules = ["harness"]

--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -21,10 +21,10 @@ The harness is shipped as a single Python module + a Dockerfile, distributed via
 ```bash
 git clone https://github.com/stefanobaghino/sublime-mcp.git
 cd sublime-mcp
-pipx install -e .
+uv tool install --editable .
 ```
 
-`pipx install -e` keeps `sublime-mcp` pointing at this checkout — pulling new commits picks them up; switching branches switches the harness code. Plain `pip install -e .` works too if you already have a managed environment.
+`uv tool install --editable .` keeps `sublime-mcp` pointing at this checkout — pulling new commits picks them up; switching branches switches the harness code. `pipx install -e .` and plain `pip install -e .` work too if you already have one of those set up.
 
 ## Register with Claude Code
 


### PR DESCRIPTION
## Summary

Swap `pipx install -e .` for `uv tool install --editable .` as the primary install path in `README.md` (lines 42-51 and the uninstall block) and `skills/sublime-mcp/install.md`. The `pyproject.toml` install-time comment moves with it. `pipx` and `pip install -e .` stay documented as fallbacks for users who already have one configured.

`uv tool install --editable .` is a one-for-one replacement for the editable install: both leave a `sublime-mcp` shim on PATH whose source resolves back to the checkout, which is what `harness.py`'s `build_context_dir()` needs to find the bundled `Dockerfile`, `docker/entrypoint.sh`, and `sublime_mcp.py`. Editable mode is currently load-bearing — see the `[tool.setuptools] py-modules` comment.

`uvx` is deferred. `uvx --from <path>` builds a non-editable wheel, and the bundled assets aren't shipped as package data, so `build_context_dir()` would fail at first run. A v2 layout that declares the Dockerfile + entrypoint as package data unlocks a `uvx --from git+https://…` zero-install flow.

## Test plan

- [ ] `uv tool install --editable .` from a checkout produces a working `sublime-mcp` on PATH (smoke: `sublime-mcp --help`)
- [ ] `claude mcp add --scope user --transport stdio sublime-text -- sublime-mcp --mount "$PWD:/work"` followed by `claude mcp list` shows `sublime-text ✓ Connected`
- [ ] `mcp__sublime-text__exec_sublime_python({ code: "print(sublime.version())" })` returns the ST build
