### PR TITLE
Cache Docker layers in harness-smoke

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -15,9 +15,20 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: docker/setup-buildx-action@v3
       - name: Pre-build the image
         # Done as a separate step so build time is visible in CI logs
         # and the test step only measures container boot + readiness.
-        run: docker build -t sublime-mcp-harness:latest .
+        # `cache-from/to: type=gha` reuses Docker layers across runs;
+        # the apt + Sublime Text install layers stay cached unless the
+        # Dockerfile or a `COPY`'d input changes. `load: true` keeps the
+        # built image in the local Docker daemon for the next step.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: sublime-mcp-harness:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Run harness smoke test
         run: python3 tests/test_harness_smoke.py


### PR DESCRIPTION
Cuts `harness-smoke` runtime by caching Docker layers across runs. The bare `docker build` in `.github/workflows/harness-smoke.yml` is replaced with `docker/build-push-action@v6` fronted by `docker/setup-buildx-action@v3`, with `cache-from/to: type=gha`. The apt + Sublime Text install layers — the dominant cost — stay cached unless the `Dockerfile` or `COPY`'d inputs (`sublime_mcp.py`, `docker/entrypoint.sh`) change. `load: true` keeps the built image in the local Docker daemon so `tests/test_harness_smoke.py` finds it.

Expected: first run on this branch is a cache miss (still ~3–5 min, seeds the cache). Subsequent runs and PRs after this lands on main hit the cache and finish in ~30–60s.
