### PR TITLE
Use Azure apt mirror in Dockerfile; pin base by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@
 # plugin_loaded() bind sublime-mcp's HTTP server on 127.0.0.1:47823
 # inside the container. A volume can be mounted at /work.
 
-FROM ubuntu:24.04
+# Pinned by digest so a silent base-image republication doesn't
+# invalidate every downstream layer. Bump intentionally.
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
@@ -15,7 +17,14 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # GTK + locales are the same dependency set SublimeText/UnitTesting's
 # Docker image uses for headless ST. Xvfb provides the virtual display;
 # psmisc gives `pkill` (used by the entrypoint's shutdown trap).
-RUN apt-get update \
+#
+# The sed swaps the deb822 sources to azure.archive.ubuntu.com: GitHub's
+# Linux runners are Azure VMs and the runner OS itself already points
+# there, so colocated traffic is far faster and more reliable than the
+# public archive/security mirrors (which have stalled this build for
+# >15 min on retry storms).
+RUN sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; s|http://security.ubuntu.com|http://azure.archive.ubuntu.com|g' /etc/apt/sources.list.d/ubuntu.sources \
+ && apt-get -o Acquire::Retries=2 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 update \
  && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
@@ -38,7 +47,7 @@ RUN install -d /etc/apt/keyrings \
       | gpg --dearmor -o /etc/apt/keyrings/sublimehq-archive.gpg \
  && echo "deb [signed-by=/etc/apt/keyrings/sublimehq-archive.gpg] https://download.sublimetext.com/ apt/stable/" \
       > /etc/apt/sources.list.d/sublime-text.list \
- && apt-get update \
+ && apt-get -o Acquire::Retries=2 -o Acquire::http::Timeout=20 -o Acquire::https::Timeout=20 update \
  && apt-get install -y --no-install-recommends sublime-text \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
[`harness-smoke` run 25344713876](https://github.com/stefanobaghino/sublime-mcp/actions/runs/25344713876/job/74310761038) hit the 20-min ceiling in `apt-get update`: `security.ubuntu.com` `Ign:` retries burned ~13 min, `archive.ubuntu.com` averaged 40 kB/s. The runner OS itself already targets `azure.archive.ubuntu.com` because GitHub's Linux runners are Azure VMs; the container did not. Local `--platform=linux/amd64` cold build now fetches the same 37.8 MB index in 3 s with zero retries. `Acquire::Retries=2` / `Timeout=20` cap a flaky-mirror tail. Base image is pinned by digest so a silent republication can't invalidate the apt layer cache.

## Test plan

- `harness-smoke-linux` on this PR is the cold-cache exercise: it should finish in ≪20 min and every `Get:` URI in the build log should be `azure.archive.ubuntu.com`.
- A subsequent push without Dockerfile changes should hit the GHA cache and skip the apt step entirely.
