### PR TITLE
Add health_check MCP tool for wedge detection (#73)

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -95,7 +95,9 @@ Reach for this skill when the question is "what does Sublime Text do / see / say
 
 If borderline, say which way you're leaning in one sentence, then proceed.
 
-## 3. The one tool and its contract
+## 3. The tools and their contracts
+
+### 3.1 exec_sublime_python
 
 `mcp__sublime-text__exec_sublime_python({ code })` runs `code` on a dedicated daemon thread inside the containerised ST's plugin host (Python 3.8) and returns:
 
@@ -112,6 +114,18 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
 
 **Paths are container-side.** Every path you pass into `exec_sublime_python` (to `scope_at`, `run_syntax_tests`, etc.) is resolved inside the container, not on the host. The user mounts host directories into the container at registration time; the recommended mount is `--mount $PWD:/work` so a host `~/Projects/foo/syntax_test_x.cs` becomes `/work/foo/syntax_test_x.cs` in calls. If a path you'd expect to resolve raises `FileNotFoundError`, check the user's mount before retrying; ask them rather than guessing the host-to-container mapping. `/tmp` is per-container scratch — safe to write synthetic syntax/input files into when the user's working tree shouldn't be touched.
+
+### 3.2 health_check
+
+`mcp__sublime-text__health_check({})` is a worker-thread-only probe that detects when ST's main thread is wedged. It returns within ~2.5s regardless of main-thread state and never goes near the 60s `exec_sublime_python` ceiling. Response shape:
+
+```json
+{ "main_thread_responsive": true, "main_thread_probe_elapsed_s": 0.01, "plugin_host_pid": 2060, "uptime_s": 142, "container_id": "<docker cid>", "st_version": 4200, "st_channel": "stable" }
+```
+
+**Call pattern.** When an `exec_sublime_python` call times out at 60s on something that touched the main thread (`scope_at`, `find_resources`, `open_file`, `assign_syntax_and_wait`, anything wrapped in `run_on_main`), call `health_check` *before* the next main-thread snippet. If `main_thread_responsive` is `false`, stop issuing main-thread snippets — every one will burn another 60s. Ask the user to restart the container; do not retry. If `main_thread_responsive` is `true`, the previous timeout was about that specific snippet, not a session-wide wedge — retrying is fine.
+
+**`/mcp` reconnect does not clear a wedged main thread.** Per #73 (2026-05-05): the slash-command reports `Reconnected to sublime-text.` and re-establishes the MCP transport, but the underlying ST process keeps running with the same wedged main thread — the next `set_timeout(callback, 0); event.wait(...)` still returns False. Recovery requires a true container restart (`docker kill $(docker ps --filter label=sublime-mcp-harness -q)`, then re-register). Don't read "Reconnected" as "wedge cleared."
 
 ## 4. Recipes
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -18,6 +18,7 @@ import logging
 import os
 import sys
 import threading
+import time
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
@@ -1484,21 +1485,89 @@ def _exec_on_worker(code):
     return result
 
 
-def _tool_descriptor():
-    return {
-        "name": "exec_sublime_python",
-        "description": TOOL_DESCRIPTION,
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string",
-                    "description": "Python source to exec inside Sublime Text's plugin host.",
-                }
+_HEALTH_CHECK_DESCRIPTION = (
+    "Worker-thread-only probe that detects when ST's main thread is "
+    "wedged. Returns within ~2.5s regardless of main-thread state — "
+    "schedules a no-op via sublime.set_timeout(..., 0) and waits at most "
+    "2.0s for it to fire. Use before issuing main-thread-touching "
+    "exec_sublime_python calls if the previous exec timed out at the 60s "
+    "ceiling. If main_thread_responsive is False, ask the user to restart "
+    "the container — `/mcp` reconnect does not clear the wedge."
+)
+
+
+def _tool_descriptors():
+    return [
+        {
+            "name": "exec_sublime_python",
+            "description": TOOL_DESCRIPTION,
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "string",
+                        "description": "Python source to exec inside Sublime Text's plugin host.",
+                    }
+                },
+                "required": ["code"],
             },
-            "required": ["code"],
         },
+        {
+            "name": "health_check",
+            "description": _HEALTH_CHECK_DESCRIPTION,
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        },
+    ]
+
+
+_MAIN_THREAD_PROBE_TIMEOUT_S = 2.0
+
+
+def _run_health_check():
+    """Probe ST main-thread responsiveness without touching `_exec_on_worker`.
+
+    Schedules `done.set` via `sublime.set_timeout(..., 0)` and waits up to
+    `_MAIN_THREAD_PROBE_TIMEOUT_S` seconds. The wait runs on the HTTP
+    request thread (a daemon) so this returns even when ST's main thread
+    is wedged — point of the whole fix per #73.
+    """
+    done = threading.Event()
+    started = time.monotonic()
+    try:
+        sublime.set_timeout(done.set, 0)
+    except Exception:
+        # set_timeout itself failing means ST is not just wedged but gone.
+        # Treat as unresponsive; let the caller branch on it.
+        logger.warning("health_check: sublime.set_timeout raised", exc_info=True)
+        responsive = False
+    else:
+        responsive = done.wait(_MAIN_THREAD_PROBE_TIMEOUT_S)
+    elapsed = time.monotonic() - started
+    if _startup_monotonic is not None:
+        uptime_s = int(time.monotonic() - _startup_monotonic)
+    else:
+        uptime_s = 0
+    payload = {
+        "main_thread_responsive": bool(responsive),
+        "main_thread_probe_elapsed_s": round(elapsed, 3),
+        "plugin_host_pid": os.getpid(),
+        "uptime_s": uptime_s,
+        "container_id": os.environ.get("HOSTNAME") or None,
+        "st_version": int(sublime.version()),
+        "st_channel": sublime.channel(),
     }
+    logger.info(
+        "health_check responsive=%s elapsed=%.2fs uptime=%ds pid=%d",
+        payload["main_thread_responsive"],
+        payload["main_thread_probe_elapsed_s"],
+        payload["uptime_s"],
+        payload["plugin_host_pid"],
+    )
+    return payload
 
 
 def _dispatch(message):
@@ -1525,34 +1594,45 @@ def _dispatch(message):
         return {
             "jsonrpc": "2.0",
             "id": req_id,
-            "result": {"tools": [_tool_descriptor()]},
+            "result": {"tools": _tool_descriptors()},
         }
 
     if method == "tools/call":
         name = params.get("name")
         arguments = params.get("arguments") or {}
-        if name != "exec_sublime_python":
+        if name == "exec_sublime_python":
+            code = arguments.get("code")
+            if not isinstance(code, str):
+                return {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32602, "message": "arguments.code must be a string"},
+                }
+            outcome = _exec_on_worker(code)
+            text = json.dumps(outcome, indent=2, default=str)
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "error": {"code": -32602, "message": "unknown tool: %s" % name},
+                "result": {
+                    "content": [{"type": "text", "text": text}],
+                    "isError": outcome["error"] is not None,
+                },
             }
-        code = arguments.get("code")
-        if not isinstance(code, str):
+        if name == "health_check":
+            payload = _run_health_check()
+            text = json.dumps(payload, indent=2, default=str)
             return {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "error": {"code": -32602, "message": "arguments.code must be a string"},
+                "result": {
+                    "content": [{"type": "text", "text": text}],
+                    "isError": False,
+                },
             }
-        outcome = _exec_on_worker(code)
-        text = json.dumps(outcome, indent=2, default=str)
         return {
             "jsonrpc": "2.0",
             "id": req_id,
-            "result": {
-                "content": [{"type": "text", "text": text}],
-                "isError": outcome["error"] is not None,
-            },
+            "error": {"code": -32602, "message": "unknown tool: %s" % name},
         }
 
     if method == "ping":
@@ -1653,11 +1733,14 @@ class MCPHandler(BaseHTTPRequestHandler):
 
 _server = None
 _thread = None
+_startup_monotonic = None
 
 
 def plugin_loaded():
-    global _server, _thread
+    global _server, _thread, _startup_monotonic
     _configure_bridge_logging()
+    if _startup_monotonic is None:
+        _startup_monotonic = time.monotonic()
     if _server is not None:
         return
     try:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -319,11 +319,154 @@ class TestUnifiedLogging(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    _RUNNING_IN_SUBLIME,
+    "test_logging.py drives a host-side Docker harness; not applicable inside ST plugin host",
+)
+class TestHealthCheck(unittest.TestCase):
+    """Coverage for the `health_check` MCP tool surface (#73 part 1).
+
+    `health_check` runs entirely on the HTTP request thread — its purpose
+    is to return within ~2.5s even when ST's main thread is wedged. The
+    wedged-main test below installs a ~6s sleep on ST's main thread via a
+    fast-returning snippet, then calls `health_check` and asserts the
+    response arrives in well under the would-be 60s exec ceiling.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not _docker_available():
+            raise unittest.SkipTest("docker not available")
+
+    def test_tools_list_includes_health_check(self) -> None:
+        proc = _spawn_harness()
+        captured: list = []
+        try:
+            _wait_ready(proc, captured, time.monotonic() + READY_TIMEOUT_S)
+            _send(proc, {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {},
+            })
+            resp = _recv(proc, timeout_s=DEFAULT_CALL_TIMEOUT_S)
+        finally:
+            _shutdown(proc)
+        self.assertEqual(resp.get("id"), 1, resp)
+        names = sorted(t["name"] for t in resp["result"]["tools"])
+        self.assertEqual(names, ["exec_sublime_python", "health_check"])
+
+    def test_health_check_responsive(self) -> None:
+        proc = _spawn_harness()
+        captured: list = []
+        try:
+            _wait_ready(proc, captured, time.monotonic() + READY_TIMEOUT_S)
+            started = time.monotonic()
+            _send(proc, {
+                "jsonrpc": "2.0",
+                "id": 42,
+                "method": "tools/call",
+                "params": {"name": "health_check", "arguments": {}},
+            })
+            resp = _recv(proc, timeout_s=DEFAULT_CALL_TIMEOUT_S)
+            elapsed = time.monotonic() - started
+        finally:
+            _shutdown(proc)
+
+        self.assertEqual(resp.get("id"), 42, resp)
+        self.assertFalse(resp["result"]["isError"], resp)
+        payload = json.loads(resp["result"]["content"][0]["text"])
+        for key in (
+            "main_thread_responsive",
+            "main_thread_probe_elapsed_s",
+            "plugin_host_pid",
+            "uptime_s",
+            "container_id",
+            "st_version",
+            "st_channel",
+        ):
+            self.assertIn(key, payload, payload)
+        self.assertTrue(payload["main_thread_responsive"], payload)
+        self.assertLess(payload["main_thread_probe_elapsed_s"], 0.5, payload)
+        self.assertGreater(payload["plugin_host_pid"], 0)
+        self.assertGreaterEqual(payload["uptime_s"], 0)
+        self.assertGreater(payload["st_version"], 4000)
+        # End-to-end roundtrip well under the 60s ceiling — proves the
+        # tool isn't accidentally routed through `_exec_on_worker`.
+        self.assertLess(elapsed, 5.0, "responsive health_check took %.2fs" % elapsed)
+
+    def test_health_check_during_wedge(self) -> None:
+        """While ST's main thread is sleeping, `health_check` returns quickly.
+
+        Unlike `test_wedge_logs_faulthandler`, this test does NOT need to
+        wait for the 60s exec ceiling — the wedge-installer snippet
+        returns immediately on the worker thread (it just schedules a
+        `set_timeout` callback and exits), so we can send `health_check`
+        right away and observe the unresponsive main thread for the
+        duration of the scheduled sleep.
+        """
+        proc = _spawn_harness()
+        captured: list = []
+        try:
+            _wait_ready(proc, captured, time.monotonic() + READY_TIMEOUT_S)
+            wedge_install = (
+                "import time\n"
+                "sublime.set_timeout(lambda: time.sleep(6), 0)\n"
+            )
+            _send(proc, {
+                "jsonrpc": "2.0",
+                "id": 100,
+                "method": "tools/call",
+                "params": {
+                    "name": "exec_sublime_python",
+                    "arguments": {"code": wedge_install},
+                },
+            })
+            resp_install = _recv(proc, timeout_s=DEFAULT_CALL_TIMEOUT_S)
+            self.assertEqual(resp_install.get("id"), 100, resp_install)
+            # ST schedules the timeout off the main loop; give it a beat
+            # so the sleep is actually in flight before we probe.
+            time.sleep(0.3)
+
+            started = time.monotonic()
+            _send(proc, {
+                "jsonrpc": "2.0",
+                "id": 101,
+                "method": "tools/call",
+                "params": {"name": "health_check", "arguments": {}},
+            })
+            resp = _recv(proc, timeout_s=DEFAULT_CALL_TIMEOUT_S)
+            elapsed = time.monotonic() - started
+        finally:
+            _shutdown(proc)
+
+        self.assertEqual(resp.get("id"), 101, resp)
+        payload = json.loads(resp["result"]["content"][0]["text"])
+        self.assertFalse(
+            payload["main_thread_responsive"],
+            "expected main_thread_responsive=False during wedge: %s" % payload,
+        )
+        # Probe is internally capped at 2.0s; allow generous slack on
+        # round-trip. The contract that justifies the whole tool is "not
+        # 60s" — assert well under that.
+        self.assertLess(
+            elapsed, 4.0,
+            "health_check during wedge took %.2fs" % elapsed,
+        )
+        self.assertGreaterEqual(
+            payload["main_thread_probe_elapsed_s"], 1.5, payload,
+        )
+
+
 def run() -> int:
     if not _docker_available():
         print("SKIP: docker not available", file=sys.stderr)
         return 0
-    suite = unittest.defaultTestLoader.loadTestsFromTestCase(TestUnifiedLogging)
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite([
+        loader.loadTestsFromTestCase(TestUnifiedLogging),
+        loader.loadTestsFromTestCase(TestHealthCheck),
+    ])
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)
     return 0 if result.wasSuccessful() else 1


### PR DESCRIPTION
Closes #73 (the layered fix's part 1). Adds `health_check`, a worker-thread-only MCP tool that detects when ST's main thread is wedged in <2.5s — the high-leverage detection primitive that lets an agent decide "retry" vs "ask user to restart container" in one turn instead of burning N×60s timeouts. The probe schedules `done.set` via `sublime.set_timeout(..., 0)` on the HTTP request thread and waits at most 2.0s for it to fire; if main is sleeping in `time.sleep(70)` (the canonical #73 wedge shape), `done.wait` returns False and `main_thread_responsive` lands as `false`. Response also carries `plugin_host_pid`, `uptime_s` (captured in `plugin_loaded` at module load), `container_id` (from `HOSTNAME`), and `st_version` / `st_channel` to match the existing tool's envelope.

SKILL.md §3 splits into 3.1 (`exec_sublime_python`) and 3.2 (`health_check`), with the §3.2 body documenting the post-timeout call pattern and recording the #73-comment-2 finding that `/mcp` reconnect does **not** clear a wedged main thread — only a true container restart does. The `install.md` "restart the agent session" recipe is overstated and is a separate doc fix.

Out of scope: `restart_st()` (#73 part 2), which needs a relaunch loop in `docker/entrypoint.sh:55-60` and port-rebind detection on the harness side; filed once we have usage data on whether agents reach for the recovery primitive when surfaced.

## Test plan

- New `TestHealthCheck` class in `tests/test_logging.py` (3 unguarded cases: tools/list contains both descriptors; healthy probe returns `main_thread_responsive=True` in <0.5s with the full payload shape; wedged probe — short scheduled sleep on main — returns `main_thread_responsive=False` in <4s with `probe_elapsed >= 1.5s`).
- All 6 cases in `tests/test_logging.py` pass locally on a freshly-rebuilt image, including the existing `RUN_SLOW_LOG_TESTS=1 test_wedge_logs_faulthandler` regression (67s).
- `tests/test_harness_smoke.py` still green (PASS marker on round-trip + ST 4200).
