### PR TITLE
Echo cid + workspace_path; warn on harness-self-mount

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -112,12 +112,14 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 `mcp__sublime-text__exec_sublime_python({ code })` runs `code` on a dedicated daemon thread inside the containerised ST's plugin host (Python 3.8) and returns:
 
 ```json
-{ "output": "<captured print()>", "result": "<repr(_) or null>", "error": "<traceback or null>", "st_version": 4200, "st_channel": "stable", "isError": false }
+{ "output": "<captured print()>", "result": "<repr(_) or null>", "error": "<traceback or null>", "st_version": 4200, "st_channel": "stable", "container_id": "<docker cid>", "workspace_path": "/work", "isError": false }
 ```
 
 - A trailing bare expression is auto-lifted into `_`, or assign to `_` explicitly at top level. Either way, `repr(_)` is returned as `result`.
 - `error` is populated on uncaught exception; `isError` is derived from `error is not None`. Helper failures (e.g. `run_syntax_tests` cannot complete the run) raise and surface in this same `error` field — there is no separate helper-level error channel.
 - `st_version` (int) and `st_channel` (str, e.g. `"stable"` / `"dev"`) echo the running ST build on every response. Use these to detect channel mismatches when probing grammars whose CI gates on a non-stable channel.
+- `container_id` is the Docker short cid of the harness container handling the call. When recovery requires `docker kill` / `docker exec`, use this field rather than `docker ps --filter label=sublime-mcp-harness -q` (which lists *every* harness container on the host — multiple Claude Code sessions can run concurrently).
+- `workspace_path` is the in-container mount root paths resolve against — always `/work` when the user followed the install instructions. Treat it as the contract anchor: every path argument you pass to `scope_at` / `run_syntax_tests` / `open_view` is interpreted against this root.
 - `run_syntax_tests(...)["state"]` reports the assertion-run outcome (`passed` / `failed`). `failures` is ST's raw multi-line diagnostic per assertion; `failures_structured` is the same list parsed into `{file, row, col, error_label, expected_selector, actual}` dicts for programmatic consumers (best-effort; `failures` remains canonical on parser miss).
 - Preloaded helpers (`scope_at`, `scope_at_test`, `resolve_position`, `run_syntax_tests`, `open_view`, `assign_syntax_and_wait`, `find_resources`, `reload_syntax`) are in scope without import.
 
@@ -130,7 +132,7 @@ For the full helper surface, threading guarantees, and the authoritative `text_p
 `mcp__sublime-text__health_check({})` is a worker-thread-only probe that detects when ST's main thread is wedged. It returns within ~2.5s regardless of main-thread state and never goes near the 60s `exec_sublime_python` ceiling. Response shape:
 
 ```json
-{ "main_thread_responsive": true, "main_thread_probe_elapsed_s": 0.01, "plugin_host_pid": 2060, "uptime_s": 142, "container_id": "<docker cid>", "st_version": 4200, "st_channel": "stable" }
+{ "main_thread_responsive": true, "main_thread_probe_elapsed_s": 0.01, "plugin_host_pid": 2060, "uptime_s": 142, "container_id": "<docker cid>", "workspace_path": "/work", "st_version": 4200, "st_channel": "stable" }
 ```
 
 **Call pattern.** When an `exec_sublime_python` call times out at 60s on something that touched the main thread (`scope_at`, `find_resources`, `open_file`, `assign_syntax_and_wait`, anything wrapped in `run_on_main`), call `health_check` *before* the next main-thread snippet. If `main_thread_responsive` is `false`, stop issuing main-thread snippets — every one will burn another 60s. Ask the user to restart the container; do not retry. If `main_thread_responsive` is `true`, the previous timeout was about that specific snippet, not a session-wide wedge — retrying is fine.

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -38,6 +38,12 @@ ENDPOINT = "/mcp"
 EXEC_TIMEOUT_SECONDS = 60.0
 OPEN_FILE_TIMEOUT_SECONDS = 5.0
 
+# Container-side mount root. The harness's recommended invocation
+# (`--mount $PWD:/work`) places the user's project tree here; paths
+# passed into `exec_sublime_python` resolve against it. Echoed in
+# response envelopes so callers have a contract anchor.
+WORKSPACE_PATH = "/work"
+
 LOG_FORMAT = (
     "%(asctime)s.%(msecs)03d  %(levelname)-7s  [%(component)s]  "
     "req=%(req_id)s  %(message)s"
@@ -1380,11 +1386,17 @@ def _exec_on_worker(code):
     """Run `code` on a dedicated daemon thread and collect output.
 
     Returns a dict with keys `output`, `result`, `error`, `st_version`,
-    `st_channel`. `error is None` means the snippet ran to completion.
-    `st_version` / `st_channel` echo the running ST build so callers can
-    detect when they're driving (e.g.) ST stable while their question
-    was authored against ST DEV — read per-call so an in-place ST
-    upgrade is reflected without restart.
+    `st_channel`, `container_id`, `workspace_path`. `error is None`
+    means the snippet ran to completion. `st_version` / `st_channel`
+    echo the running ST build so callers can detect when they're
+    driving (e.g.) ST stable while their question was authored against
+    ST DEV — read per-call so an in-place ST upgrade is reflected
+    without restart. `container_id` (Docker `HOSTNAME`) lets a host-side
+    recovery script identify which `sublime-mcp-harness` container
+    owns a given response without grep-and-reverse-map (#74).
+    `workspace_path` is the contract anchor for paths passed into
+    helpers — always `/work` when the user followed install instructions
+    (#76).
     """
     done = threading.Event()
     # ST guarantees `sublime.version()` is a stringified integer; cast
@@ -1395,6 +1407,8 @@ def _exec_on_worker(code):
         "error": None,
         "st_version": int(sublime.version()),
         "st_channel": sublime.channel(),
+        "container_id": os.environ.get("HOSTNAME") or None,
+        "workspace_path": WORKSPACE_PATH,
     }
 
     # Capture the parent's request id so the worker thread's log lines
@@ -1557,6 +1571,7 @@ def _run_health_check():
         "plugin_host_pid": os.getpid(),
         "uptime_s": uptime_s,
         "container_id": os.environ.get("HOSTNAME") or None,
+        "workspace_path": WORKSPACE_PATH,
         "st_version": int(sublime.version()),
         "st_channel": sublime.channel(),
     }
@@ -1736,9 +1751,39 @@ _thread = None
 _startup_monotonic = None
 
 
+def _looks_like_harness_source(entries):
+    """Predicate for the harness-self-mount detection (#76).
+
+    The user's recommended invocation is `--mount $PWD:/work`. When
+    they register the MCP server from inside the sublime-mcp source
+    repo and then drive a different project, `/work` ends up bound to
+    the harness source instead of their workspace — and the agent
+    sees `Dockerfile` / `sublime_mcp.py` / `harness.py` and assumes
+    that's the project. Both `sublime_mcp.py` and `Dockerfile`
+    co-occur at the top only in the harness source repo; either alone
+    is too loose.
+    """
+    return "sublime_mcp.py" in entries and "Dockerfile" in entries
+
+
+def _warn_if_harness_self_mounted():
+    try:
+        entries = set(os.listdir(WORKSPACE_PATH))
+    except OSError:
+        return
+    if _looks_like_harness_source(entries):
+        logger.warning(
+            "%s appears to be the harness source repo, not a project "
+            "workspace. Re-register the MCP server from your project "
+            "directory if this is unintended.",
+            WORKSPACE_PATH,
+        )
+
+
 def plugin_loaded():
     global _server, _thread, _startup_monotonic
     _configure_bridge_logging()
+    _warn_if_harness_self_mounted()
     if _startup_monotonic is None:
         _startup_monotonic = time.monotonic()
     if _server is not None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -62,13 +62,19 @@ LOG_LINE_RE = re.compile(
 )
 
 
-def _spawn_harness(env: dict | None = None) -> subprocess.Popen:
+def _spawn_harness(
+    env: dict | None = None,
+    extra_args: list[str] | None = None,
+) -> subprocess.Popen:
     full_env = os.environ.copy()
     full_env["PYTHONUNBUFFERED"] = "1"
     if env:
         full_env.update(env)
+    cmd = [sys.executable, "-u", str(HARNESS)]
+    if extra_args:
+        cmd.extend(extra_args)
     return subprocess.Popen(
-        [sys.executable, "-u", str(HARNESS)],
+        cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -382,6 +388,7 @@ class TestHealthCheck(unittest.TestCase):
             "plugin_host_pid",
             "uptime_s",
             "container_id",
+            "workspace_path",
             "st_version",
             "st_channel",
         ):
@@ -391,6 +398,7 @@ class TestHealthCheck(unittest.TestCase):
         self.assertGreater(payload["plugin_host_pid"], 0)
         self.assertGreaterEqual(payload["uptime_s"], 0)
         self.assertGreater(payload["st_version"], 4000)
+        self.assertEqual(payload["workspace_path"], "/work", payload)
         # End-to-end roundtrip well under the 60s ceiling — proves the
         # tool isn't accidentally routed through `_exec_on_worker`.
         self.assertLess(elapsed, 5.0, "responsive health_check took %.2fs" % elapsed)
@@ -458,6 +466,120 @@ class TestHealthCheck(unittest.TestCase):
         )
 
 
+@unittest.skipIf(
+    _RUNNING_IN_SUBLIME,
+    "test_logging.py drives a host-side Docker harness; not applicable inside ST plugin host",
+)
+class TestExecSublimePythonEnvelope(unittest.TestCase):
+    """Coverage for the situational-awareness fields on `exec_sublime_python` (#74, #76).
+
+    `container_id` lets a host-side recovery script identify which
+    `sublime-mcp-harness` container owns a given response without
+    grep-and-reverse-mapping artefact filenames. `workspace_path` is the
+    contract anchor for paths the agent passes back into helpers.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        if not _docker_available():
+            raise unittest.SkipTest("docker not available")
+
+    def test_envelope_includes_container_id_and_workspace_path(self) -> None:
+        proc = _spawn_harness()
+        captured: list = []
+        try:
+            _wait_ready(proc, captured, time.monotonic() + READY_TIMEOUT_S)
+            _send(proc, {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "exec_sublime_python",
+                    "arguments": {"code": "2 + 2\n"},
+                },
+            })
+            resp = _recv(proc, timeout_s=DEFAULT_CALL_TIMEOUT_S)
+        finally:
+            _shutdown(proc)
+
+        self.assertEqual(resp.get("id"), 11, resp)
+        self.assertFalse(resp["result"]["isError"], resp)
+        payload = json.loads(resp["result"]["content"][0]["text"])
+        for key in (
+            "output",
+            "result",
+            "error",
+            "st_version",
+            "st_channel",
+            "container_id",
+            "workspace_path",
+        ):
+            self.assertIn(key, payload, payload)
+        self.assertIsNone(payload["error"], payload)
+        self.assertEqual(payload["result"], "4", payload)
+        self.assertEqual(payload["workspace_path"], "/work", payload)
+        # `HOSTNAME` inside Docker is the 12-char short cid.
+        cid = payload["container_id"]
+        self.assertIsInstance(cid, str, payload)
+        self.assertRegex(cid, r"^[0-9a-f]{12}$", payload)
+
+
+@unittest.skipIf(
+    _RUNNING_IN_SUBLIME,
+    "test_logging.py drives a host-side Docker harness; not applicable inside ST plugin host",
+)
+class TestHarnessSelfMountWarning(unittest.TestCase):
+    """`plugin_loaded()` warns when /work shadows the harness source repo (#76)."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not _docker_available():
+            raise unittest.SkipTest("docker not available")
+
+    def test_warning_fires_when_repo_mounted_at_work(self) -> None:
+        # Mounting the repo at /work is the canonical mistake: the user
+        # registered the MCP server from inside the sublime-mcp source
+        # tree. Both `sublime_mcp.py` and `Dockerfile` are present at
+        # the top, which is the predicate the helper checks.
+        proc = _spawn_harness(extra_args=["--mount", "%s:/work" % REPO])
+        captured: list = []
+        try:
+            _wait_ready(proc, captured, time.monotonic() + READY_TIMEOUT_S)
+            # The warning is emitted from `plugin_loaded` before the
+            # HTTP-server bind, but the bridge logger's writes race
+            # the harness's tail thread; drain a beat to avoid flake.
+            _drain_stderr(proc, captured, until_s=1.5)
+        finally:
+            _shutdown(proc)
+            if proc.stderr is not None:
+                tail = proc.stderr.read()
+                if tail:
+                    captured.append(tail)
+
+        blob = b"".join(captured).decode("utf-8", "replace")
+        self.assertRegex(
+            blob,
+            r"WARNING\s+\[bridge\].*appears to be the harness source repo",
+            "expected harness-self-mount warning in unified log stream",
+        )
+
+    def test_warning_silent_without_mount(self) -> None:
+        proc = _spawn_harness()
+        captured: list = []
+        try:
+            _wait_ready(proc, captured, time.monotonic() + READY_TIMEOUT_S)
+            _drain_stderr(proc, captured, until_s=1.0)
+        finally:
+            _shutdown(proc)
+            if proc.stderr is not None:
+                tail = proc.stderr.read()
+                if tail:
+                    captured.append(tail)
+
+        blob = b"".join(captured).decode("utf-8", "replace")
+        self.assertNotIn("appears to be the harness source repo", blob)
+
+
 def run() -> int:
     if not _docker_available():
         print("SKIP: docker not available", file=sys.stderr)
@@ -466,6 +588,8 @@ def run() -> int:
     suite = unittest.TestSuite([
         loader.loadTestsFromTestCase(TestUnifiedLogging),
         loader.loadTestsFromTestCase(TestHealthCheck),
+        loader.loadTestsFromTestCase(TestExecSublimePythonEnvelope),
+        loader.loadTestsFromTestCase(TestHarnessSelfMountWarning),
     ])
     runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(suite)


### PR DESCRIPTION
Closes #74. Closes #76.

`exec_sublime_python` and `health_check` now both echo `container_id` (Docker `HOSTNAME` short cid) and `workspace_path` (`/work`) on every response. The cid lets a host-side recovery script identify which `sublime-mcp-harness` container owns a given response without grep-and-reverse-mapping artefact filenames — needed when multiple Claude Code sessions share a host. `workspace_path` is the contract anchor for paths the agent passes back into helpers; treating it as the answer to "where do my paths resolve?" lets the agent skip a round-trip when the user's mount is unconventional.

`plugin_loaded()` now warns when `/work` shadows the harness source repo. The detection is a co-occurrence check on the two files that exist together only in this repo (`sublime_mcp.py`, `Dockerfile`); the warning routes through the bridge logger and surfaces in the unified harness stderr stream live (per #83's now-corrected SKILL §1.1).

PR #82 already landed `[harness] container started cid=<short-cid>` as a boot log line. The follow-up comment on #74 (2026-05-05T07:04Z) noted the boot line freezes the cid at boot rather than capturing it live, and not every consumer of `exec_sublime_python` reads the harness's MCP-log channel. This PR closes that gap on the response side.

`workspace_path` is the container-side mount root. The host-side path (which would require the harness to pass `$PWD` through as a container env var) is not bundled — the startup warning catches the canonical harness-self-mount case at registration time, and the host-side echo is a follow-up if dogfooding shows it's needed.

## Test plan

- New `TestExecSublimePythonEnvelope` and `TestHarnessSelfMountWarning` classes in `tests/test_logging.py`, plus the existing `test_health_check_responsive` augmented to assert `workspace_path == "/work"`. All 9 cases pass locally on a freshly-rebuilt image (the new tests required a `docker build` since `sublime_mcp.py` is `COPY`-ed in).
- `tests/test_harness_smoke.py` still green.
- The harness-self-mount warning test mounts `$REPO:/work` and asserts the regex `WARNING\s+\[bridge\].*appears to be the harness source repo` appears in the unified stderr; the silent-case test asserts the same string is absent when no mount is supplied.
