### PR TITLE
Document host-side write footgun and ^-alignment rule in SKILL.md

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -188,6 +188,8 @@ Branch on `state` for the assertion-run outcome:
 
 When ST cannot complete the run, `run_syntax_tests` raises `RuntimeError` and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. The reachable causes are: resource not yet indexed, path outside `sublime.packages_path()` (symlink it in first — see "Confirm which syntax ST assigned (and handle repo-local syntaxes)" below), and the private `sublime_api.run_syntax_test` missing on this ST build. For ground-truth questions that don't need the assertion runner, fall back to `scope_at` / `scope_at_test` or `resolve_position`.
 
+The `^` alignment rule that defines what each assertion line targets is documented under *Probe a synthetic case inline* below.
+
 ### Probe a synthetic case inline
 
 For "what does ST do on this case?" probes against a syntax that's *already reachable to ST* — bundled, or linked into `Packages/` via `temp_packages_link` — `run_inline_syntax_test(content, name)` owns the file-write, indexing wait, runner call, and cleanup. The header inside `content` selects the syntax under test.
@@ -203,6 +205,8 @@ print(r["state"], r["summary"])
 ```
 
 Same `{state, summary, output, failures}` shape as `run_syntax_tests`, with one extra state `"inconclusive"` when ST never indexes the temp resource within the wait budget. The probe's temp dir is removed on every code path (within-call `try/finally`); a cross-call sweep at the start of each call cleans up SIGKILL-orphaned dirs older than 60 s.
+
+**Assertion-line `^` alignment.** Each `^` in an assertion line tests the column it sits in on the assertion line — the same column on the content line directly above. The leading columns are taken up by the comment marker (`#` ⇒ col 0 unreachable; `//` ⇒ cols 0–1 unreachable, with the conventional trailing space pushing the testable region to col 3+). Probes targeting those leading columns of the content line cannot be expressed through `^`. Pad the content with leading spaces if you need to test the leading region, or prefer the single-char `# SYNTAX TEST` header that maximises the reachable range. For "scope at point" probes that don't need assertion-runner output, prefer `scope_at` / `scope_at_test` / `resolve_position` — they accept any column directly.
 
 This helper writes only the *test file*. When the syntax under test is also synthetic, pair `temp_packages_link` (own the syntax) with `resolve_position` / `scope_at` (sample the input) — see the next recipe.
 

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -125,7 +125,7 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
 
-**Paths are container-side.** Every path you pass into `exec_sublime_python` (to `scope_at`, `run_syntax_tests`, etc.) is resolved inside the container, not on the host. The user mounts host directories into the container at registration time; the recommended mount is `--mount $PWD:/work` so a host `~/Projects/foo/syntax_test_x.cs` becomes `/work/foo/syntax_test_x.cs` in calls. If a path you'd expect to resolve raises `FileNotFoundError`, check the user's mount before retrying; ask them rather than guessing the host-to-container mapping. `/tmp` is per-container scratch — safe to write synthetic syntax/input files into when the user's working tree shouldn't be touched.
+**Paths are container-side.** Every path you pass into `exec_sublime_python` (to `scope_at`, `run_syntax_tests`, etc.) is resolved inside the container, not on the host. The user mounts host directories into the container at registration time; the recommended mount is `--mount $PWD:/work` so a host `~/Projects/foo/syntax_test_x.cs` becomes `/work/foo/syntax_test_x.cs` in calls. If a path you'd expect to resolve raises `FileNotFoundError`, check the user's mount before retrying; ask them rather than guessing the host-to-container mapping. If the call hangs or times out instead of raising, the host-side-write footgun is the likely cause — same root, different shape; see §4. `/tmp` is per-container scratch — safe to write synthetic syntax/input files into when the user's working tree shouldn't be touched.
 
 ### 3.2 health_check
 
@@ -142,6 +142,8 @@ For the full helper surface, threading guarantees, and the authoritative `text_p
 ## 4. Recipes
 
 Each recipe is one `exec_sublime_python` call. Rows and columns are **0-indexed** — a test-file assertion on line 181 col 9 is `row=180, col=8`. Paths shown are container-side; the user typically mounts their working tree at `/work`.
+
+**Host-side file-write tools.** If you're driving this skill from an agent harness with its own host-side write tool (Claude Code's `Write`, Cursor's edit tool, anything similar), don't pre-write probe files to host paths and then pass those paths into `exec_sublime_python` helpers. The container only sees paths under `--mount` directories (typically `/work`) plus its own `/tmp`; anything else is invisible regardless of how the path looks on the host. The failure shape is a hang or indexer-budget timeout (the #67 / #73 surfaces), not a clean `FileNotFoundError`. Write probe files inside the snippet instead — see *Probe a synthetic case inline* and *Probe a synthetic syntax against a synthetic input* below.
 
 ### Scope at a position
 


### PR DESCRIPTION
Closes #68. Closes #81.

Two SKILL.md paper cuts the user hit in the 2026-05-04/05 sessions, bundled into one PR:

**#81 — host-side write footgun.** When an agent harness has its own host-side write tool (Claude Code's `Write`, Cursor's edit tool), the natural workflow is "write probe files to host paths, then point `temp_packages_link` / `resolve_position` at them." That fails: the container only sees paths under `--mount` directories plus its own `/tmp`. The failure shape is a hang or indexer-budget timeout (the #67 / #73 surfaces), not a clean `FileNotFoundError` — different from the existing §3 "Paths are container-side" prose. The fix adds a §4 caveat near the top of *Recipes* and a one-sentence cross-link from §3.

**#68 — `^` alignment with comment-marker columns.** Each `^` in an assertion line tests the column it sits in on the assertion line, which is the same column on the content line above. The leading columns occupied by the comment marker are unreachable through `^` (`#` ⇒ col 0; `//` with conventional trailing space ⇒ cols 0–2). Implicit in every example, never stated. The fix adds an *Assertion-line `^` alignment* paragraph to *Probe a synthetic case inline* (where the `^` is most visible in the example) and a one-line cross-reference from *Run syntax tests against a file*.

Both edits are doc-only; no code or test surface touched. Per the issue authors' explicit recommendations, the lighter-touch option is enough — no defensive code-side check on `temp_packages_link`, no `[(row, col, expected_scope)]` mode for `run_inline_syntax_test`. Cross-link to #66's recipe (referenced in #68) is deferred until #66 lands.

## Test plan

- No new tests; SKILL.md is consumed by the agent harness, not by the plugin host or `tests/`.
- CI gates (`run-tests` macOS + ubuntu, `harness-smoke-linux`, `headless-smoke-macos`) are unchanged from main and should all pass green.
- Manual: re-read the new paragraphs in context; confirm they land as the natural extension of surrounding prose.
