### PR TITLE
Expose wait_for_resource helper for cross-snippet indexing waits

### DIFF
--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -260,6 +260,8 @@ The returned dict also carries `overflow` (past-EOL request wrapped into a later
 
 `temp_packages_link` synthesises a unique nonce-named package, so the bundled `Packages/Java` continues to load alongside it — `requested_syntax != resolved_syntax` still flags any silent fallback to a built-in. The per-syntax mode is sufficient for synthetic probes and single-grammar regression triage; cross-grammar investigations where the testdata grammar embeds another testdata grammar (e.g. C# embedding RegExp) need a whole-tree mirror that shadows the built-ins, tracked separately in §6.
 
+When a caller writes additional `.sublime-syntax` files into the already-linked dir between snippets — incremental probing — wait for them to surface via `wait_for_resource("MyProbe*.sublime-syntax")` from a follow-up snippet, *not* an in-snippet `find_resources` poll. An in-snippet poll that overruns `EXEC_TIMEOUT_SECONDS` is killed at the transport, but the main-thread state it touched can leave ST wedged for the rest of the session (#64).
+
 `scope_at_test` parses the URI from the file's `SYNTAX TEST` header (conventionally `Packages/...` already) and exposes the same `requested_syntax` / `resolved_syntax` pair without needing a symlink. `run_syntax_tests` accepts any path under `sublime.packages_path()` (directly or via symlink); pair it with `temp_packages_link` to cover paths outside the Packages tree.
 
 ### Compare a parser's output against ST
@@ -369,6 +371,7 @@ _Last synced with issue state: 2026-05-05._
 - `run_on_main(callable, timeout=2.0)` — schedule `callable` on ST's main thread; return its value (or re-raise its exception). Required wrapper for `view.run_command(...)` and other `TextCommand` mutations.
 - `temp_packages_link(filesystem_path) -> str` / `release_packages_link(name) -> None` — synthesise / tear down a per-call `Packages/__sublime_mcp_temp_<nonce>__` symlink for repo-local syntaxes. `filesystem_path` accepts either a `.sublime-syntax` file (links its parent directory) or a directory (links it directly). Returns the synthesised package name; build URIs as `Packages/<name>/<basename>`.
 - `find_resources(pattern) -> list[str]` — wrap `sublime.find_resources`.
+- `wait_for_resource(pattern, timeout=3.0) -> bool` — poll `find_resources(pattern)` until any match surfaces or the budget expires. Use across snippets to wait for a file written in a prior `exec_sublime_python` to surface in ST's resource index — chaining cross-snippet avoids the wedge risk of in-snippet polling that overruns `EXEC_TIMEOUT_SECONDS`.
 - `reload_syntax(resource_path) -> None` — force-reload a `.sublime-syntax` resource via view reactivation.
 
 Full signatures, gotchas, and threading guarantees live in `TOOL_DESCRIPTION` (read via `tools/list`). This reference is a cheat-sheet.

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -188,6 +188,8 @@ Branch on `state` for the assertion-run outcome:
 
 When ST cannot complete the run, `run_syntax_tests` raises `RuntimeError` and the cause surfaces in the top-level `error` of the MCP response — `isError` is true. The reachable causes are: resource not yet indexed, path outside `sublime.packages_path()` (symlink it in first — see "Confirm which syntax ST assigned (and handle repo-local syntaxes)" below), and the private `sublime_api.run_syntax_test` missing on this ST build. For ground-truth questions that don't need the assertion runner, fall back to `scope_at` / `scope_at_test` or `resolve_position`.
 
+The `^` alignment rule that defines what each assertion line targets is documented under *Probe a synthetic case inline* below.
+
 ### Probe a synthetic case inline
 
 For "what does ST do on this case?" probes against a syntax that's *already reachable to ST* — bundled, or linked into `Packages/` via `temp_packages_link` — `run_inline_syntax_test(content, name)` owns the file-write, indexing wait, runner call, and cleanup. The header inside `content` selects the syntax under test.
@@ -203,6 +205,8 @@ print(r["state"], r["summary"])
 ```
 
 Same `{state, summary, output, failures}` shape as `run_syntax_tests`, with one extra state `"inconclusive"` when ST never indexes the temp resource within the wait budget. The probe's temp dir is removed on every code path (within-call `try/finally`); a cross-call sweep at the start of each call cleans up SIGKILL-orphaned dirs older than 60 s.
+
+**Assertion-line `^` alignment.** Each `^` in an assertion line tests the column it sits in on the assertion line — the same column on the content line directly above. The leading columns are taken up by the comment marker (`#` ⇒ col 0 unreachable; `//` ⇒ cols 0–1 unreachable, with the conventional trailing space pushing the testable region to col 3+). Probes targeting those leading columns of the content line cannot be expressed through `^`. Pad the content with leading spaces if you need to test the leading region, or prefer the single-char `# SYNTAX TEST` header that maximises the reachable range. For "scope at point" probes that don't need assertion-runner output, prefer `scope_at` / `scope_at_test` / `resolve_position` — they accept any column directly.
 
 This helper writes only the *test file*. When the syntax under test is also synthetic, pair `temp_packages_link` (own the syntax) with `resolve_position` / `scope_at` (sample the input) — see the next recipe.
 

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -125,7 +125,7 @@ If borderline, say which way you're leaning in one sentence, then proceed.
 
 For the full helper surface, threading guarantees, and the authoritative `text_point` overflow semantics, read the tool's own `description` via `tools/list`. If this skill contradicts it, `tools/list` is right.
 
-**Paths are container-side.** Every path you pass into `exec_sublime_python` (to `scope_at`, `run_syntax_tests`, etc.) is resolved inside the container, not on the host. The user mounts host directories into the container at registration time; the recommended mount is `--mount $PWD:/work` so a host `~/Projects/foo/syntax_test_x.cs` becomes `/work/foo/syntax_test_x.cs` in calls. If a path you'd expect to resolve raises `FileNotFoundError`, check the user's mount before retrying; ask them rather than guessing the host-to-container mapping. `/tmp` is per-container scratch — safe to write synthetic syntax/input files into when the user's working tree shouldn't be touched.
+**Paths are container-side.** Every path you pass into `exec_sublime_python` (to `scope_at`, `run_syntax_tests`, etc.) is resolved inside the container, not on the host. The user mounts host directories into the container at registration time; the recommended mount is `--mount $PWD:/work` so a host `~/Projects/foo/syntax_test_x.cs` becomes `/work/foo/syntax_test_x.cs` in calls. If a path you'd expect to resolve raises `FileNotFoundError`, check the user's mount before retrying; ask them rather than guessing the host-to-container mapping. If the call hangs or times out instead of raising, the host-side-write footgun is the likely cause — same root, different shape; see §4. `/tmp` is per-container scratch — safe to write synthetic syntax/input files into when the user's working tree shouldn't be touched.
 
 ### 3.2 health_check
 
@@ -142,6 +142,8 @@ For the full helper surface, threading guarantees, and the authoritative `text_p
 ## 4. Recipes
 
 Each recipe is one `exec_sublime_python` call. Rows and columns are **0-indexed** — a test-file assertion on line 181 col 9 is `row=180, col=8`. Paths shown are container-side; the user typically mounts their working tree at `/work`.
+
+**Host-side file-write tools.** If you're driving this skill from an agent harness with its own host-side write tool (Claude Code's `Write`, Cursor's edit tool, anything similar), don't pre-write probe files to host paths and then pass those paths into `exec_sublime_python` helpers. The container only sees paths under `--mount` directories (typically `/work`) plus its own `/tmp`; anything else is invisible regardless of how the path looks on the host. The failure shape is a hang or indexer-budget timeout (the #67 / #73 surfaces), not a clean `FileNotFoundError`. Write probe files inside the snippet instead — see *Probe a synthetic case inline* and *Probe a synthetic syntax against a synthetic input* below.
 
 ### Scope at a position
 

--- a/sublime_mcp.py
+++ b/sublime_mcp.py
@@ -1048,6 +1048,35 @@ def _wait_for_resource(resource_path, timeout=3.0):
     return False
 
 
+def wait_for_resource(pattern, timeout=3.0):
+    # Public counterpart to _wait_for_resource. Returns True if any
+    # resource matching the glob pattern surfaces within the budget,
+    # False otherwise. Use this from snippet callers that have just
+    # written a file into Packages/User/ (or under an existing
+    # temp_packages_link) and need to wait for ST's resource indexer
+    # to surface it before sampling.
+    #
+    # Prefer chaining this across snippets — write the file in one
+    # exec, poll in a second — over polling inside the same snippet.
+    # An in-snippet poll that exceeds EXEC_TIMEOUT_SECONDS is killed
+    # at the transport, but the main-thread work it triggered can
+    # leave ST wedged for the rest of the session (#64).
+    start = _time.time()
+    deadline = start + timeout
+    refresh_threshold = start + (timeout * 2.0 / 3.0)
+    refreshed = False
+    while _time.time() < deadline:
+        if find_resources(pattern):
+            return True
+        if not refreshed and _time.time() >= refresh_threshold:
+            sublime.set_timeout(
+                lambda: sublime.run_command("refresh_folder_list"), 0
+            )
+            refreshed = True
+        _time.sleep(0.02)
+    return False
+
+
 _TEMP_DIR_PREFIX = "__sublime_mcp_temp_"
 _TEMP_DIR_SUFFIX = "__"
 _TEMP_DIR_MAX_AGE_SECONDS = 60.0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -991,6 +991,87 @@ class TestWaitForResource(HelperTestBase):
         self.assertEqual(lines[1].count("refresh_folder_list"), 1)
 
 
+class TestWaitForResourcePublic(HelperTestBase):
+    """`wait_for_resource(pattern, timeout=3.0)` is the public glob-
+    pattern counterpart to the private `_wait_for_resource(path, …)`
+    used internally by `temp_packages_link`. Returns True when any
+    resource matching the pattern surfaces within the budget, False
+    otherwise — exposed so callers can chain indexing waits across
+    snippets instead of polling inside one (#64).
+    """
+
+    def test_default_timeout_is_three_seconds(self):
+        # The default is the externally-visible contract; anchor it
+        # via inspect.signature to mirror the _wait_for_resource test.
+        code = (
+            "import inspect\n"
+            "_ = inspect.signature(wait_for_resource).parameters['timeout'].default\n"
+            "print(_)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "3.0")
+
+    def test_returns_true_for_existing_resource(self):
+        # `find_resources` matches basename globs against ST's resource
+        # index. `Python.sublime-syntax` is bundled with ST 4 and
+        # present from startup, so the helper should return True well
+        # within the default budget.
+        code = (
+            "found = wait_for_resource('Python.sublime-syntax')\n"
+            "print(found)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        self.assertEqual(outcome["output"].strip(), "True")
+
+    def test_returns_false_when_pattern_misses(self):
+        # Tight budget so the test runs in well under a second; the
+        # pattern is constructed to never match anything in ST's index.
+        code = (
+            "import time\n"
+            "t0 = time.time()\n"
+            "found = wait_for_resource('__sublime_mcp_nonexistent__.sublime-syntax', timeout=0.1)\n"
+            "elapsed = time.time() - t0\n"
+            "print(found)\n"
+            "print(elapsed < 0.5)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        lines = outcome["output"].strip().splitlines()
+        self.assertEqual(lines[0], "False")
+        self.assertEqual(lines[1], "True")
+
+    def test_refresh_folder_list_fires_after_two_thirds(self):
+        # Mirror the _wait_for_resource refresh-nudge test. Patch
+        # sublime.run_command so the test doesn't actually nudge ST's
+        # indexer. 0.3 s budget → refresh at ~0.2 s → ~0.1 s of post-
+        # refresh polling before the deadline. set_timeout dispatch
+        # is async; sleep within the patch context after the wait
+        # returns so the lambda has time to land on main.
+        code = (
+            "import time\n"
+            "import unittest.mock\n"
+            "calls = []\n"
+            "with unittest.mock.patch.object(sublime, 'run_command', new=lambda *a, **k: calls.append(a)):\n"
+            "    found = wait_for_resource('__sublime_mcp_nonexistent__.sublime-syntax', timeout=0.3)\n"
+            "    time.sleep(0.3)\n"
+            "print(found)\n"
+            "print(calls)\n"
+        )
+        resp = yield from _call_tool_yielding(code)
+        outcome = _outcome(resp)
+        self.assertIsNone(outcome["error"], outcome.get("error"))
+        lines = outcome["output"].strip().splitlines()
+        self.assertEqual(lines[0], "False")
+        self.assertIn("refresh_folder_list", lines[1])
+        # Make sure it fired exactly once, not on every poll iteration.
+        self.assertEqual(lines[1].count("refresh_folder_list"), 1)
+
+
 class TestRunInlineSyntaxTest(HelperTestBase):
     """`run_inline_syntax_test` writes a probe file under
     `Packages/User/__sublime_mcp_temp_<nonce>__/`, runs ST's syntax-


### PR DESCRIPTION
Closes #64.

Adds a public `wait_for_resource(pattern, timeout=3.0) -> bool` to `HELPERS_SOURCE`, next to the existing private `_wait_for_resource`. Returns True when any resource matching the glob pattern surfaces in ST's index within the budget, False otherwise. Default budget matches `_wait_for_resource`'s 3.0 s settled by #6.

The OP framed this as ergonomics — hand-rolled `find_resources` polling appeared 3 times in one 2026-05-04 session. The 2026-05-04T22:25Z follow-up comment escalates it: an in-snippet `find_resources` poll that exceeded `EXEC_TIMEOUT_SECONDS` was killed at the transport, but the main-thread state it touched left ST wedged for the rest of the session — every subsequent snippet (including `len(sublime.windows())`) timed out, and recovery required killing ST inside the container, which itself failed because `plugin_host-3.8` never re-spawned. The session was parked.

Exposing the helper lets callers chain across snippets — write the file in one `exec_sublime_python`, poll in a second — so the worst case becomes "the poll snippet returns False after 3 s" rather than "the harness wedges."

Polling shape duplicates `_wait_for_resource`'s loop rather than refactoring behind a shared predicate helper. Two call sites, ~12 lines each, no drift pressure; refactoring would risk regressing `temp_packages_link`'s reliance on the existing private surface. Semantics differ: `_wait_for_resource` checks for an exact resource path match (its `temp_packages_link` use), `wait_for_resource` returns True when any match surfaces under a glob pattern (the issue's signature).

Doc: SKILL.md §7 gains a reference entry next to `find_resources`; §4's `temp_packages_link` recipe gains a wedge-prevention callout pointing to the new helper for incremental probing.

## Test plan

- New `TestWaitForResourcePublic` class in `tests/test_helpers.py`: signature default (`inspect.signature(wait_for_resource).parameters['timeout'].default == 3.0`), hit on `Python.sublime-syntax`, miss within ~0.5 s on a guaranteed-nonexistent basename, refresh-folder-list nudge after two-thirds of the budget. Mirrors the existing `TestWaitForResource` shape so any future refactor keeps the two surfaces in lockstep.
- CI gates: `run-tests` (macOS + ubuntu), `harness-smoke-linux`, `headless-smoke-macos` should all pass green.
- Manual smoke deferred to dogfooding — the change is shaped for incremental probing sessions where the wedge from #64's comment surfaced.
