### PR TITLE
Name harness container st-<agent>-<session-id>

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,16 @@ list resources. Agents should read it as their primary reference.
 ## Harness flags
 
 ```
-sublime-mcp [--mount HOST:CONTAINER] [--image-tag TAG]
+sublime-mcp --agent-name AGENT --session-id UUID
+            [--mount HOST:CONTAINER] [--image-tag TAG]
             [--rebuild] [--license-file PATH]
 ```
 
+- `--agent-name AGENT` (required): name of the agent owning this
+  session. Sanitized to `[a-z0-9-]` and used to name the container as
+  `st-<agent>-<session-id>`.
+- `--session-id UUID` (required): session identifier, matched against
+  `[A-Za-z0-9-]{1,64}`. Used to name the container.
 - `--mount HOST:CONTAINER` (repeatable): bind-mount HOST into the
   container at CONTAINER. Recommended: `--mount $PWD:/work`.
 - `--image-tag TAG`: override the image tag (default
@@ -117,13 +123,20 @@ sublime-mcp [--mount HOST:CONTAINER] [--image-tag TAG]
 - `--license-file PATH`: mount a Sublime Text license file into the
   container's `~/.config/sublime-text/Local/`.
 
+Both `--agent-name` and `--session-id` are dynamic per session;
+Claude Code's MCP launch is a static argv, so register the harness via
+a small launcher script that fills them in from the surrounding
+context (see [`skills/sublime-mcp/install.md`](skills/sublime-mcp/install.md)).
+
 ## Multi-agent
 
 Each agent session spawns its own harness; each harness owns its own
 container. Host ports are kernel-assigned, so concurrent agents on the
-same machine don't collide. `docker ps --filter
-label=sublime-mcp-harness` lists the running containers; the label
-value is the harness's PID.
+same machine don't collide. Containers are named
+`st-<agent>-<session-uuid>`, so `docker ps` directly shows which
+session owns which container. `docker ps --filter
+label=sublime-mcp-harness` is also still supported — the label value
+is the harness's PID.
 
 ## Tests
 

--- a/harness.py
+++ b/harness.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import queue
+import re
 import shutil
 import signal
 import subprocess
@@ -93,6 +94,26 @@ logger = logging.getLogger("sublime_mcp.harness")
 # Argument parsing
 
 
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9-]{1,64}$")
+_AGENT_NAME_SUB = re.compile(r"[^a-z0-9-]+")
+CONTAINER_NAME_MAX = 253  # Docker container name limit.
+
+
+def _sanitize_agent_name(name: str) -> str:
+    """Lowercase + collapse non-`[a-z0-9-]` runs into a single `-`."""
+    cleaned = _AGENT_NAME_SUB.sub("-", name.lower())
+    return cleaned.strip("-")
+
+
+def _container_name(agent: str, session_id: str) -> str:
+    """Build `st-<agent>-<session-id>`, truncating agent if name is too long."""
+    name = "st-%s-%s" % (agent, session_id)
+    if len(name) > CONTAINER_NAME_MAX:
+        budget = CONTAINER_NAME_MAX - len("st--") - len(session_id)
+        name = "st-%s-%s" % (agent[:max(budget, 1)], session_id)
+    return name
+
+
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="sublime-mcp",
@@ -128,6 +149,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Logging level for harness + bridge (also $SUBLIME_MCP_LOG_LEVEL). "
              "Default: %(default)s.",
     )
+    parser.add_argument(
+        "--agent-name",
+        required=True,
+        metavar="AGENT",
+        help="Name of the Claude Code agent owning this session. "
+             "Used to name the container as st-<agent>-<session-id>.",
+    )
+    parser.add_argument(
+        "--session-id",
+        required=True,
+        metavar="UUID",
+        help="Claude Code session UUID. Used to name the container.",
+    )
     args = parser.parse_args(argv)
     if args.log_level not in LOG_LEVELS:
         parser.error("--log-level must be one of %s, got %r" % (LOG_LEVELS, args.log_level))
@@ -136,6 +170,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             parser.error("--mount expects HOST:CONTAINER, got %r" % spec)
     if args.license_file and not Path(args.license_file).is_file():
         parser.error("--license-file %r is not a regular file" % args.license_file)
+    sanitized_agent = _sanitize_agent_name(args.agent_name)
+    if not sanitized_agent:
+        parser.error(
+            "--agent-name %r contains no [a-z0-9-] characters after sanitization"
+            % args.agent_name
+        )
+    args.agent_name = sanitized_agent
+    if not _SESSION_ID_RE.match(args.session_id):
+        parser.error(
+            "--session-id %r must match [A-Za-z0-9-]{1,64}" % args.session_id
+        )
     return args
 
 
@@ -252,11 +297,14 @@ def run_container(
     mounts: list[str],
     license_file: str | None,
     log_level: str = "INFO",
+    *,
+    name: str,
 ) -> str:
     args = [
         "docker", "run",
         "-d",
         "--rm",
+        "--name", name,
         "--label", "sublime-mcp-harness=%d" % os.getpid(),
         "-p", "127.0.0.1:0:%d" % CONTAINER_PORT,
         "-e", "SUBLIME_MCP_LOG_LEVEL=%s" % log_level,
@@ -616,12 +664,16 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("docker build failed (exit %d)", exc.returncode)
         return exc.returncode or 1
 
+    container_name = _container_name(args.agent_name, args.session_id)
     try:
-        cid = run_container(args.image_tag, args.mount, args.license_file, args.log_level)
+        cid = run_container(
+            args.image_tag, args.mount, args.license_file, args.log_level,
+            name=container_name,
+        )
     except subprocess.CalledProcessError as exc:
         logger.error("docker run failed (exit %d): %s", exc.returncode, exc.stderr or "")
         return exc.returncode or 1
-    logger.info("container started cid=%s", cid[:12])
+    logger.info("container started cid=%s name=%s", cid[:12], container_name)
 
     stop_event = threading.Event()
 

--- a/skills/sublime-mcp/install.md
+++ b/skills/sublime-mcp/install.md
@@ -28,10 +28,23 @@ uv tool install --editable .
 
 ## Register with Claude Code
 
+The harness requires `--agent-name` and `--session-id` so each container can be named `st-<agent>-<session>` and matched back to the session that owns it. Both must come from the live agent context, so register the harness via a tiny launcher script (Claude Code's MCP launch is a static argv; it can't template per-session values directly):
+
+```bash
+# ~/.local/bin/sublime-mcp-launcher
+#!/usr/bin/env bash
+exec sublime-mcp \
+    --agent-name "${CLAUDE_AGENT_NAME:-claude-code}" \
+    --session-id "${CLAUDE_SESSION_ID:?CLAUDE_SESSION_ID must be set}" \
+    --mount "$PWD:/work" "$@"
+```
+
 ```bash
 claude mcp add --scope user --transport stdio sublime-text -- \
-    sublime-mcp --mount "$PWD:/work"
+    sublime-mcp-launcher
 ```
+
+The launcher is the place to thread agent/session info from whatever the surrounding harness exposes (env vars, hook input, etc.). The harness itself hard-fails if either flag is missing.
 
 The name `sublime-text` is load-bearing: the skill's `allowed-tools` hard-codes `mcp__sublime-text__exec_sublime_python`. Registered under a different name, the skill won't see the tool.
 
@@ -65,7 +78,7 @@ The plugin host inside the container is wedged. Restart the agent session (closi
 
 ### Multi-agent: ports / containers
 
-Each agent session spawns its own harness, which spawns its own container. Host ports are kernel-assigned (`-p 127.0.0.1:0:47823`), so concurrent agents don't collide. `docker ps --filter label=sublime-mcp-harness` lists them — the label value is the harness's PID, useful for matching a container to a specific session.
+Each agent session spawns its own harness, which spawns its own container. Host ports are kernel-assigned (`-p 127.0.0.1:0:47823`), so concurrent agents don't collide. `docker ps --filter label=sublime-mcp-harness` lists them; container names are `st-<agent>-<session-uuid>`, so the agent and session that own each container are visible in `docker ps` directly. The `sublime-mcp-harness=<pid>` label is still set for backwards-compatible filtering.
 
 Each ST instance uses ~100–300 MB RAM. If you routinely run many concurrent agents, watch overall memory pressure.
 
@@ -105,7 +118,7 @@ Success: `summary` is a numeric "N assertions passed" or "FAILED: M of N asserti
 ```bash
 claude mcp remove sublime-text
 claude mcp add --scope user --transport stdio sublime-text -- \
-    sublime-mcp --mount "$PWD:/work"
+    sublime-mcp-launcher
 ```
 
 The name `sublime-text` is load-bearing: this skill's `allowed-tools` hard-codes `mcp__sublime-text__exec_sublime_python`. Registered under a different name, the skill won't see the tool.

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -21,6 +21,7 @@ import signal
 import subprocess
 import sys
 import time
+import uuid
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -89,7 +90,11 @@ def run() -> int:
 
     # `python -u` keeps stdout/stderr unbuffered so we see ready promptly.
     proc = subprocess.Popen(
-        [sys.executable, "-u", str(HARNESS)],
+        [
+            sys.executable, "-u", str(HARNESS),
+            "--agent-name", "harness-smoke",
+            "--session-id", str(uuid.uuid4()),
+        ],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import time
 import unittest
+import uuid
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
@@ -70,7 +71,11 @@ def _spawn_harness(
     full_env["PYTHONUNBUFFERED"] = "1"
     if env:
         full_env.update(env)
-    cmd = [sys.executable, "-u", str(HARNESS)]
+    cmd = [
+        sys.executable, "-u", str(HARNESS),
+        "--agent-name", "test-logging",
+        "--session-id", str(uuid.uuid4()),
+    ]
     if extra_args:
         cmd.extend(extra_args)
     return subprocess.Popen(


### PR DESCRIPTION
## Summary

Replace Docker's auto-generated container name with `st-<agent>-<session-id>` so `docker ps` is self-documenting in multi-session setups. Two new required harness flags drive the name (`--agent-name`, `--session-id`); the harness hard-fails if either is missing. The existing `sublime-mcp-harness=<pid>` label is kept for backwards-compatible filtering.

Claude Code's MCP launch is a static argv, so a launcher-script pattern is documented in `skills/sublime-mcp/install.md` for threading dynamic per-session values through. Note: `CLAUDE_AGENT_NAME` / `CLAUDE_SESSION_ID` in that example are placeholders — Claude Code does not currently export those by default, so the launcher will need to read whichever env vars/hook input the surrounding wiring exposes.

## Test plan

- [x] `python harness.py` (no flags) → exits 2 with "the following arguments are required: --agent-name, --session-id".
- [x] `python harness.py --agent-name '' --session-id abc123` → exits 2 with the sanitization error.
- [x] `python harness.py --agent-name foo --session-id 'bad/id'` → exits 2 with the session-id-format error.
- [x] `_sanitize_agent_name` smoke: "Claude Code" → "claude-code", "allium:tend" → "allium-tend", "---explore---" → "explore".
- [x] `tests/test_harness_smoke.py` boots the container and round-trips `initialize` + `exec_sublime_python`; harness logs `container started cid=… name=st-harness-smoke-<uuid>`.
