### PR TITLE
Derive image tag from git HEAD; refuse dirty trees

### DIFF
--- a/.github/workflows/harness-smoke.yml
+++ b/.github/workflows/harness-smoke.yml
@@ -30,6 +30,8 @@ jobs:
           load: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Run image-tag derivation tests
+        run: python3 tests/test_image_tag.py
       - name: Run harness smoke test
         run: python3 tests/test_harness_smoke.py
       - name: Run unified-log shape test

--- a/README.md
+++ b/README.md
@@ -117,9 +117,14 @@ sublime-mcp --agent-name AGENT --session-id UUID
   `[A-Za-z0-9-]{1,64}`. Used to name the container.
 - `--mount HOST:CONTAINER` (repeatable): bind-mount HOST into the
   container at CONTAINER. Recommended: `--mount $PWD:/work`.
-- `--image-tag TAG`: override the image tag (default
-  `sublime-mcp-harness:latest`).
-- `--rebuild`: force `docker build` even if the image already exists.
+- `--image-tag TAG`: override the image tag. Default: derived from
+  `git rev-parse HEAD` against the harness checkout as
+  `sublime-mcp-harness:<sha12>`. The harness refuses to run when the
+  source isn't a git repo or the work tree is dirty (any staged,
+  unstaged, or untracked change) — pass `--image-tag` to bypass.
+- `--rebuild`: force `docker build` even if an image with the resolved
+  tag already exists. Useful only to recover from a corrupted local
+  image cache.
 - `--license-file PATH`: mount a Sublime Text license file into the
   container's `~/.config/sublime-text/Local/`.
 
@@ -191,5 +196,8 @@ the harness is the supported user path.
 ```sh
 claude mcp remove sublime-text --scope user
 uv tool uninstall sublime-mcp-harness
-docker image rm sublime-mcp-harness:latest
+docker images --filter "label=sublime-mcp-harness-image" -q | xargs -r docker image rm
 ```
+
+Pre-`v0.1.x`-upgrade users may also have a stale `sublime-mcp-harness:latest`;
+remove it with `docker image rm sublime-mcp-harness:latest 2>/dev/null` if so.

--- a/harness.py
+++ b/harness.py
@@ -33,7 +33,13 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-DEFAULT_IMAGE_TAG = "sublime-mcp-harness:latest"
+IMAGE_REPO = "sublime-mcp-harness"
+# Build-time label key applied to every image we build, so cleanup can
+# target this project's images precisely:
+#   docker images --filter "label=sublime-mcp-harness-image" -q
+# Distinct from the *container* label `sublime-mcp-harness=<pid>`
+# applied by `run_container`, which serves a different purpose.
+IMAGE_LABEL_KEY = "sublime-mcp-harness-image"
 CONTAINER_PORT = 47823
 CONTAINER_LICENSE_DIR = "/root/.config/sublime-text/Local"
 READINESS_TIMEOUT_S = 60.0
@@ -129,13 +135,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--image-tag",
-        default=DEFAULT_IMAGE_TAG,
-        help="Image tag to look up / build. Default: %(default)s",
+        default=None,
+        help="Override the image tag. Default: derived from "
+             "`git rev-parse HEAD` against the harness checkout as "
+             "`sublime-mcp-harness:<sha12>`. The harness refuses to run "
+             "when the source isn't a git repo or its work tree is dirty; "
+             "passing this flag bypasses both checks.",
     )
     parser.add_argument(
         "--rebuild",
         action="store_true",
-        help="Force `docker build` even if the image already exists.",
+        help="Force `docker build` even if an image with the resolved "
+             "tag already exists. Useful only to recover from a "
+             "corrupted local image cache.",
     )
     parser.add_argument(
         "--license-file",
@@ -221,6 +233,50 @@ def stage_build_context(src: Path) -> Path:
 
 
 # ---------------------------------------------------------------------
+# Git-derived image tag
+
+
+def derive_image_tag(src: Path) -> str:
+    """Return `sublime-mcp-harness:<git-sha12>` for the harness checkout at `src`.
+
+    Refuses if `src` isn't inside a git work tree or the work tree is
+    dirty (any staged, unstaged, or untracked change). The tag must
+    unambiguously identify a committed state. Pass `--image-tag` to
+    bypass both checks.
+    """
+    inside = subprocess.run(
+        ["git", "-C", str(src), "rev-parse", "--is-inside-work-tree"],
+        capture_output=True,
+        text=True,
+    )
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        raise RuntimeError(
+            "harness source at %s is not a git repository — "
+            "pass --image-tag to override or run from a clone of the "
+            "sublime-mcp source repo" % src
+        )
+    status = subprocess.run(
+        ["git", "-C", str(src), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    if status.stdout.strip():
+        raise RuntimeError(
+            "harness source at %s has uncommitted changes — "
+            "commit or stash before running, or pass --image-tag to "
+            "override.\nDirty paths:\n%s" % (src, status.stdout.rstrip())
+        )
+    head = subprocess.run(
+        ["git", "-C", str(src), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return "%s:%s" % (IMAGE_REPO, head.stdout.strip()[:12])
+
+
+# ---------------------------------------------------------------------
 # Docker calls
 
 
@@ -264,7 +320,12 @@ def image_exists(tag: str) -> bool:
 def build_image(tag: str, context: Path) -> None:
     logger.info("building image %s (this can take a few minutes on first run)…", tag)
     subprocess.run(
-        ["docker", "build", "-t", tag, str(context)],
+        [
+            "docker", "build",
+            "--label", "%s=%s" % (IMAGE_LABEL_KEY, tag),
+            "-t", tag,
+            str(context),
+        ],
         check=True,
     )
     logger.info("image %s built", tag)
@@ -658,8 +719,18 @@ def main(argv: list[str] | None = None) -> int:
         logger.error("%s", exc)
         return 2
 
+    if args.image_tag is None:
+        try:
+            tag = derive_image_tag(ctx)
+        except RuntimeError as exc:
+            logger.error("%s", exc)
+            return 2
+        logger.info("derived image tag %s from git HEAD", tag)
+    else:
+        tag = args.image_tag
+
     try:
-        ensure_image(args.image_tag, args.rebuild, ctx)
+        ensure_image(tag, args.rebuild, ctx)
     except subprocess.CalledProcessError as exc:
         logger.error("docker build failed (exit %d)", exc.returncode)
         return exc.returncode or 1
@@ -667,7 +738,7 @@ def main(argv: list[str] | None = None) -> int:
     container_name = _container_name(args.agent_name, args.session_id)
     try:
         cid = run_container(
-            args.image_tag, args.mount, args.license_file, args.log_level,
+            tag, args.mount, args.license_file, args.log_level,
             name=container_name,
         )
     except subprocess.CalledProcessError as exc:

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -89,9 +89,13 @@ def run() -> int:
         return 0
 
     # `python -u` keeps stdout/stderr unbuffered so we see ready promptly.
+    # `--image-tag sublime-mcp-harness:latest` matches the tag CI's
+    # pre-build step uses; a clean checkout would otherwise resolve a
+    # different (git-derived) tag and trigger a redundant build here.
     proc = subprocess.Popen(
         [
             sys.executable, "-u", str(HARNESS),
+            "--image-tag", "sublime-mcp-harness:latest",
             "--agent-name", "harness-smoke",
             "--session-id", str(uuid.uuid4()),
         ],

--- a/tests/test_image_tag.py
+++ b/tests/test_image_tag.py
@@ -1,0 +1,144 @@
+"""Unit tests for `derive_image_tag` (no Docker required).
+
+Verifies that the git-derived tag refuses dirty / non-repo sources and
+matches the first 12 chars of `git rev-parse HEAD` when the work tree
+is clean. Skips if `git --version` does not work.
+
+Run standalone (`python3 tests/test_image_tag.py`) or via pytest; the
+script self-skips on either entrypoint.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from harness import IMAGE_REPO, build_context_dir, derive_image_tag  # noqa: E402
+
+TAG_RE = re.compile(r"^%s:[0-9a-f]{12}$" % re.escape(IMAGE_REPO))
+
+
+def _git_available() -> bool:
+    if shutil.which("git") is None:
+        return False
+    result = subprocess.run(
+        ["git", "--version"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+class _Skip(Exception):
+    pass
+
+
+@unittest.skipUnless(_git_available(), "`git` not on PATH")
+class DeriveImageTagTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp(prefix="sublime-mcp-tag-test-"))
+        # Local-config-only env so user/system git config (signing, hooks,
+        # commit templates) doesn't bleed into the synthetic repo.
+        self.env = {
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _git(self, *argv: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", "-C", str(self.tmp), *argv],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=self.env,
+        )
+
+    def _init_clean_repo(self) -> str:
+        """Init a repo with one committed file, return the HEAD sha."""
+        self._git("init", "-q", "-b", "main")
+        (self.tmp / "fixture.txt").write_text("hello\n")
+        self._git("add", "fixture.txt")
+        self._git("commit", "-q", "-m", "initial")
+        head = self._git("rev-parse", "HEAD").stdout.strip()
+        return head
+
+    def test_clean_repo_returns_short_sha_tag(self) -> None:
+        head = self._init_clean_repo()
+        tag = derive_image_tag(self.tmp)
+        self.assertEqual(tag, "%s:%s" % (IMAGE_REPO, head[:12]))
+
+    def test_tag_shape(self) -> None:
+        self._init_clean_repo()
+        tag = derive_image_tag(self.tmp)
+        self.assertRegex(tag, TAG_RE)
+
+    def test_dirty_work_tree_refuses(self) -> None:
+        self._init_clean_repo()
+        (self.tmp / "fixture.txt").write_text("hello\nworld\n")
+        with self.assertRaises(RuntimeError) as ctx:
+            derive_image_tag(self.tmp)
+        self.assertIn("uncommitted changes", str(ctx.exception))
+        self.assertIn("fixture.txt", str(ctx.exception))
+
+    def test_untracked_file_refuses(self) -> None:
+        self._init_clean_repo()
+        (self.tmp / "untracked.txt").write_text("x")
+        with self.assertRaises(RuntimeError) as ctx:
+            derive_image_tag(self.tmp)
+        self.assertIn("uncommitted changes", str(ctx.exception))
+        self.assertIn("untracked.txt", str(ctx.exception))
+
+    def test_non_git_dir_refuses(self) -> None:
+        with self.assertRaises(RuntimeError) as ctx:
+            derive_image_tag(self.tmp)
+        msg = str(ctx.exception)
+        self.assertIn("not a git repository", msg)
+        self.assertIn("--image-tag", msg)
+
+
+@unittest.skipUnless(_git_available(), "`git` not on PATH")
+class ProductionWiringTests(unittest.TestCase):
+    """Sanity-check that the real harness checkout's tag is shaped correctly.
+
+    Skipped when the checkout is dirty (e.g. mid-edit during dev) — the
+    derive function intentionally refuses, and we don't want to mask
+    that with a soft skip in tests.
+    """
+
+    def test_real_checkout_tag_shape(self) -> None:
+        ctx = build_context_dir()
+        status = subprocess.run(
+            ["git", "-C", str(ctx), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+        )
+        if status.returncode != 0:
+            self.skipTest("real checkout is not a git repository")
+        if status.stdout.strip():
+            self.skipTest("real checkout is dirty; not exercising derive_image_tag")
+        tag = derive_image_tag(ctx)
+        self.assertRegex(tag, TAG_RE)
+
+
+if __name__ == "__main__":
+    if not _git_available():
+        sys.stderr.write("skipping: `git` not on PATH\n")
+        sys.exit(0)
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The harness now derives the image tag from `git rev-parse HEAD` against its own checkout (`sublime-mcp-harness:<sha12>`) and refuses to run when the source isn't a git repo or the work tree is dirty. `--image-tag` bypasses both checks; `--rebuild` keeps its meaning as a recovery flag for a corrupted local image cache. Built images carry a `sublime-mcp-harness-image=<tag>` label so cleanup can target the project's images precisely.

This addresses the build-vs-source drift that surfaced during the dogfooding thread on #99 — the running container was a `:latest` baked at image-build time, ~7 hours stale relative to `sublime_mcp.py` on host, with no signal to the agent. With the new default, two sessions on the same commit share an image; different commits use different tags; mutability of `:latest` is gone. Workflow becomes "commit → restart session" rather than "edit → restart session"; users who genuinely need to test uncommitted state pass `--image-tag <anything>` to opt out.

CI's pre-build step still tags `sublime-mcp-harness:latest`; the smoke test now passes that tag explicitly so it doesn't depend on the runner's git state. New `tests/test_image_tag.py` covers clean / dirty / untracked / non-repo / shape paths against synthetic temp git repos and runs as a separate CI step before the smoke test.

Stale `sublime-mcp-harness:latest` images on pre-upgrade hosts aren't auto-removed; the README's Uninstall block now uses a label filter and notes the legacy tag.
