### PR TITLE
Allow dirty work trees; tag image as `<sha12>-dirty`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,12 @@ sublime-mcp --agent-name AGENT --session-id UUID
 - `--mount HOST:CONTAINER` (repeatable): bind-mount HOST into the
   container at CONTAINER. Recommended: `--mount $PWD:/work`.
 - `--image-tag TAG`: override the image tag. Default: derived from
-  `git rev-parse HEAD` against the harness checkout as
-  `sublime-mcp-harness:<sha12>`. The harness refuses to run when the
-  source isn't a git repo or the work tree is dirty (any staged,
-  unstaged, or untracked change) — pass `--image-tag` to bypass.
+  `git rev-parse HEAD` against the harness checkout —
+  `sublime-mcp-harness:<sha12>` when the work tree is clean, or
+  `sublime-mcp-harness:<sha12>-dirty` (with a forced rebuild from the
+  current work tree) when there are staged, unstaged, or untracked
+  changes. The harness still refuses to run when the source isn't a
+  git repo at all — pass `--image-tag` to bypass.
 - `--rebuild`: force `docker build` even if an image with the resolved
   tag already exists. Useful only to recover from a corrupted local
   image cache.

--- a/harness.py
+++ b/harness.py
@@ -236,13 +236,18 @@ def stage_build_context(src: Path) -> Path:
 # Git-derived image tag
 
 
-def derive_image_tag(src: Path) -> str:
-    """Return `sublime-mcp-harness:<git-sha12>` for the harness checkout at `src`.
+def derive_image_tag(src: Path) -> tuple[str, bool]:
+    """Return `(tag, dirty)` for the harness checkout at `src`.
 
-    Refuses if `src` isn't inside a git work tree or the work tree is
-    dirty (any staged, unstaged, or untracked change). The tag must
-    unambiguously identify a committed state. Pass `--image-tag` to
-    bypass both checks.
+    Tag is `sublime-mcp-harness:<sha12>` when the work tree is clean and
+    `sublime-mcp-harness:<sha12>-dirty` when it has any staged, unstaged,
+    or untracked change. The dirty tag is intentionally non-unique across
+    edits within the same HEAD — callers must force a rebuild when
+    `dirty` is true so the cache doesn't re-serve a stale image.
+
+    Refuses (raises `RuntimeError`) if `src` isn't inside a git work
+    tree — there's no committed sha to anchor the tag to. Pass
+    `--image-tag` to bypass.
     """
     inside = subprocess.run(
         ["git", "-C", str(src), "rev-parse", "--is-inside-work-tree"],
@@ -261,19 +266,16 @@ def derive_image_tag(src: Path) -> str:
         capture_output=True,
         text=True,
     )
-    if status.stdout.strip():
-        raise RuntimeError(
-            "harness source at %s has uncommitted changes — "
-            "commit or stash before running, or pass --image-tag to "
-            "override.\nDirty paths:\n%s" % (src, status.stdout.rstrip())
-        )
     head = subprocess.run(
         ["git", "-C", str(src), "rev-parse", "HEAD"],
         check=True,
         capture_output=True,
         text=True,
     )
-    return "%s:%s" % (IMAGE_REPO, head.stdout.strip()[:12])
+    sha12 = head.stdout.strip()[:12]
+    dirty = bool(status.stdout.strip())
+    suffix = "-dirty" if dirty else ""
+    return "%s:%s%s" % (IMAGE_REPO, sha12, suffix), dirty
 
 
 # ---------------------------------------------------------------------
@@ -721,16 +723,24 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.image_tag is None:
         try:
-            tag = derive_image_tag(ctx)
+            tag, dirty = derive_image_tag(ctx)
         except RuntimeError as exc:
             logger.error("%s", exc)
             return 2
         logger.info("derived image tag %s from git HEAD", tag)
+        if dirty:
+            logger.warning(
+                "harness source has uncommitted changes; building fresh "
+                "from the work tree. The %s tag is not reproducible — "
+                "see `git status` for the dirty paths.",
+                tag,
+            )
     else:
         tag = args.image_tag
+        dirty = False
 
     try:
-        ensure_image(tag, args.rebuild, ctx)
+        ensure_image(tag, args.rebuild or dirty, ctx)
     except subprocess.CalledProcessError as exc:
         logger.error("docker build failed (exit %d)", exc.returncode)
         return exc.returncode or 1

--- a/tests/test_image_tag.py
+++ b/tests/test_image_tag.py
@@ -1,8 +1,9 @@
 """Unit tests for `derive_image_tag` (no Docker required).
 
-Verifies that the git-derived tag refuses dirty / non-repo sources and
-matches the first 12 chars of `git rev-parse HEAD` when the work tree
-is clean. Skips if `git --version` does not work.
+Verifies that the git-derived tag matches the first 12 chars of
+`git rev-parse HEAD`, gains a `-dirty` suffix when the work tree has
+staged / unstaged / untracked changes, and refuses outright when the
+source isn't a git repo at all. Skips if `git --version` does not work.
 
 Run standalone (`python3 tests/test_image_tag.py`) or via pytest; the
 script self-skips on either entrypoint.
@@ -25,6 +26,8 @@ sys.path.insert(0, str(REPO))
 from harness import IMAGE_REPO, build_context_dir, derive_image_tag  # noqa: E402
 
 TAG_RE = re.compile(r"^%s:[0-9a-f]{12}$" % re.escape(IMAGE_REPO))
+DIRTY_TAG_RE = re.compile(r"^%s:[0-9a-f]{12}-dirty$" % re.escape(IMAGE_REPO))
+ANY_TAG_RE = re.compile(r"^%s:[0-9a-f]{12}(-dirty)?$" % re.escape(IMAGE_REPO))
 
 
 def _git_available() -> bool:
@@ -81,29 +84,29 @@ class DeriveImageTagTests(unittest.TestCase):
 
     def test_clean_repo_returns_short_sha_tag(self) -> None:
         head = self._init_clean_repo()
-        tag = derive_image_tag(self.tmp)
+        tag, dirty = derive_image_tag(self.tmp)
         self.assertEqual(tag, "%s:%s" % (IMAGE_REPO, head[:12]))
+        self.assertFalse(dirty)
 
     def test_tag_shape(self) -> None:
         self._init_clean_repo()
-        tag = derive_image_tag(self.tmp)
+        tag, _dirty = derive_image_tag(self.tmp)
         self.assertRegex(tag, TAG_RE)
 
-    def test_dirty_work_tree_refuses(self) -> None:
-        self._init_clean_repo()
+    def test_dirty_work_tree_returns_dirty_tag(self) -> None:
+        head = self._init_clean_repo()
         (self.tmp / "fixture.txt").write_text("hello\nworld\n")
-        with self.assertRaises(RuntimeError) as ctx:
-            derive_image_tag(self.tmp)
-        self.assertIn("uncommitted changes", str(ctx.exception))
-        self.assertIn("fixture.txt", str(ctx.exception))
+        tag, dirty = derive_image_tag(self.tmp)
+        self.assertEqual(tag, "%s:%s-dirty" % (IMAGE_REPO, head[:12]))
+        self.assertTrue(dirty)
+        self.assertRegex(tag, DIRTY_TAG_RE)
 
-    def test_untracked_file_refuses(self) -> None:
-        self._init_clean_repo()
+    def test_untracked_file_returns_dirty_tag(self) -> None:
+        head = self._init_clean_repo()
         (self.tmp / "untracked.txt").write_text("x")
-        with self.assertRaises(RuntimeError) as ctx:
-            derive_image_tag(self.tmp)
-        self.assertIn("uncommitted changes", str(ctx.exception))
-        self.assertIn("untracked.txt", str(ctx.exception))
+        tag, dirty = derive_image_tag(self.tmp)
+        self.assertEqual(tag, "%s:%s-dirty" % (IMAGE_REPO, head[:12]))
+        self.assertTrue(dirty)
 
     def test_non_git_dir_refuses(self) -> None:
         with self.assertRaises(RuntimeError) as ctx:
@@ -117,9 +120,8 @@ class DeriveImageTagTests(unittest.TestCase):
 class ProductionWiringTests(unittest.TestCase):
     """Sanity-check that the real harness checkout's tag is shaped correctly.
 
-    Skipped when the checkout is dirty (e.g. mid-edit during dev) — the
-    derive function intentionally refuses, and we don't want to mask
-    that with a soft skip in tests.
+    Accepts either the clean `<sha12>` tag or the `<sha12>-dirty` tag,
+    so this test stays green during contributor mid-edit runs.
     """
 
     def test_real_checkout_tag_shape(self) -> None:
@@ -131,10 +133,9 @@ class ProductionWiringTests(unittest.TestCase):
         )
         if status.returncode != 0:
             self.skipTest("real checkout is not a git repository")
-        if status.stdout.strip():
-            self.skipTest("real checkout is dirty; not exercising derive_image_tag")
-        tag = derive_image_tag(ctx)
-        self.assertRegex(tag, TAG_RE)
+        tag, dirty = derive_image_tag(ctx)
+        self.assertRegex(tag, ANY_TAG_RE)
+        self.assertEqual(dirty, bool(status.stdout.strip()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refusing to run on any uncommitted change (introduced in #105) is too strict for an iterative workflow — contributors editing the plugin shouldn't have to commit (or pass `--image-tag`) just to test inside the harness. `derive_image_tag` now returns `(tag, dirty)`: clean trees yield `<sha12>`, dirty trees yield `<sha12>-dirty`, and only non-repo sources still raise. `main` forces a rebuild when `dirty` is true so two distinct dirty states don't share a stale image — the cache-staleness bug `28efdee` set out to fix.

## Test plan

- `tests/test_image_tag.py` covers the new dirty / untracked → `<sha12>-dirty` paths, the unchanged clean → `<sha12>` path, and the still-refused non-repo path. The production-wiring case now accepts either form.
- `tests/test_harness_smoke.py` already pins `--image-tag sublime-mcp-harness:latest`, so the harness-smoke CI workflow is unaffected.
