### PR TITLE
Add wedge recovery toolkit: inspect_environment, restart_st, X-debug binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # GTK + locales are the same dependency set SublimeText/UnitTesting's
 # Docker image uses for headless ST. Xvfb provides the virtual display;
-# psmisc gives `pkill` (used by the entrypoint's shutdown trap).
+# psmisc gives `pkill` (used by the entrypoint's shutdown trap and by
+# bridge.py's `restart_st`). `x11-utils` (xdpyinfo, xwininfo, xprop) and
+# `xdotool` give the bridge and snippets a way to inspect / interact with
+# the headless display when an invisible dialog is suspected (#75) — both
+# packages combined are <5 MB.
 #
 # The sed swaps the deb822 sources to azure.archive.ubuntu.com: GitHub's
 # Linux runners are Azure VMs and the runner OS itself already points
@@ -35,6 +39,8 @@ RUN sed -i 's|http://archive.ubuntu.com|http://azure.archive.ubuntu.com|g; s|htt
         locales-all \
         psmisc \
         python3 \
+        x11-utils \
+        xdotool \
         xvfb \
  && rm -rf /var/lib/apt/lists/*
 

--- a/bridge.py
+++ b/bridge.py
@@ -5,9 +5,14 @@ stdio and proxies each request to the plugin's HTTP server on the
 container's loopback. When stdin closes (parent docker CLI dies),
 the bridge exits and the entrypoint trap tears ST and Xvfb down.
 
-This module is dormant in the image until the entrypoint is switched
-to `exec python3 /bridge.py`. While dormant, the host-side harness
-keeps proxying — see harness.py.
+Most JSON-RPC traffic is byte-forwarded to the plugin. The bridge owns
+two MCP tools that have to work even when the plugin host is
+unreachable: `inspect_environment` (worker-thread-only diagnostic of
+container-level state — processes, HTTP server, X display) and
+`restart_st` (kill ST + plugin host, relaunch via `subl --stay`, poll
+readiness). For these tools the bridge intercepts `tools/call`; for
+`tools/list` it forwards to the plugin and injects the bridge-owned
+descriptors into the response.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ import json
 import logging
 import os
 import queue
+import subprocess
 import sys
 import threading
 import time
@@ -25,7 +31,10 @@ import urllib.request
 CONTAINER_PORT = 47823
 ENDPOINT_URL = "http://127.0.0.1:%d/mcp" % CONTAINER_PORT
 READINESS_TIMEOUT_S = 60.0
+RESTART_READY_TIMEOUT_S = 30.0
 PROXY_HTTP_TIMEOUT_S = 70.0  # exec snippets cap at 60s plugin-side
+WORKSPACE_PATH = "/work"
+SUBL_LOG_PATH = "/var/log/sublime.log"
 LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")
 LOG_FORMAT = (
     "%(asctime)s.%(msecs)03d  %(levelname)-7s  [%(component)s]  "
@@ -34,6 +43,7 @@ LOG_FORMAT = (
 LOG_DATEFMT = "%Y-%m-%dT%H:%M:%S"
 
 _thread_local = threading.local()
+_BRIDGE_STARTUP_MONOTONIC: float | None = None
 
 
 class _ContextFilter(logging.Filter):
@@ -95,8 +105,7 @@ def wait_for_ready(deadline: float) -> None:
             logger.debug("ping failed: %r", exc)
         time.sleep(0.5)
     raise RuntimeError(
-        "plugin HTTP server did not respond within %.0fs: %r"
-        % (READINESS_TIMEOUT_S, last_err)
+        "plugin HTTP server did not respond within deadline: %r" % last_err
     )
 
 
@@ -149,17 +158,31 @@ def _stdin_reader(q: queue.Queue) -> None:
         q.put(line)
 
 
-def _peek_request(stripped: bytes) -> tuple[str | None, str | None]:
+def _peek_request(stripped: bytes) -> tuple[str | None, str | None, str | None]:
+    """Return (req_id, method, tool_name).
+
+    `tool_name` is populated only when method == "tools/call"; otherwise None.
+    On any parse failure, returns (None, None, None) — the proxy then forwards
+    the bytes verbatim and the plugin produces the canonical JSON-RPC error.
+    """
     try:
         body = json.loads(stripped.decode("utf-8"))
     except (ValueError, UnicodeDecodeError):
-        return None, None
+        return None, None, None
     if not isinstance(body, dict):
-        return None, None
+        return None, None, None
     raw_id = body.get("id")
     req_id = str(raw_id) if raw_id is not None else None
     method = body.get("method")
-    return req_id, method if isinstance(method, str) else None
+    method = method if isinstance(method, str) else None
+    tool_name = None
+    if method == "tools/call":
+        params = body.get("params") or {}
+        if isinstance(params, dict):
+            name = params.get("name")
+            if isinstance(name, str):
+                tool_name = name
+    return req_id, method, tool_name
 
 
 def _make_error_response(request_bytes: bytes, message: str) -> bytes:
@@ -178,6 +201,483 @@ def _make_error_response(request_bytes: bytes, message: str) -> bytes:
     return json.dumps(body).encode("utf-8")
 
 
+# Bridge-owned MCP tools — registered below their handlers are defined.
+# Maps tool name → {"descriptor": dict, "handler": callable(dict) -> dict}.
+_BRIDGE_TOOLS: dict = {}
+
+
+def _proc_state(pid: int) -> str | None:
+    """Read `/proc/<pid>/stat` and return the process-state character ('R', 'S', 'Z', ...).
+    Returns None if the process is gone or /proc is unreadable."""
+    try:
+        with open("/proc/%d/stat" % pid, "rb") as fh:
+            content = fh.read().decode("utf-8", "replace")
+    except OSError:
+        return None
+    # Format: pid (comm) state ppid ... — `comm` can contain spaces and
+    # parens, so find the *last* ')' before parsing the rest.
+    rparen = content.rfind(")")
+    if rparen < 0:
+        return None
+    rest = content[rparen + 1:].strip().split()
+    if not rest:
+        return None
+    return rest[0]
+
+
+def _pgrep_pids(pattern: str, *, exclude_zombies: bool = True) -> list[int]:
+    """Return PIDs whose `ps` line matches `pattern`; empty list on no match or error.
+
+    Zombies (`Z` state in `/proc/N/stat`) are treated as gone and excluded
+    by default. The bridge runs as PID 1 inside the container; ST processes
+    daemonized via `subl --stay` get reparented to it, and any that exit
+    without being `wait()`-ed for stay listed by `pgrep` until reaped.
+    `restart_st` reaps via `_reap_children` after the kill, but the
+    state-character filter is the authoritative "is this process alive?"
+    signal regardless.
+    """
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", pattern],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return []
+    if result.returncode not in (0, 1):  # 1 = no match, others = error
+        return []
+    pids = []
+    for line in result.stdout.split():
+        try:
+            pid = int(line.strip())
+        except ValueError:
+            continue
+        if pid == os.getpid():
+            continue
+        if exclude_zombies and _proc_state(pid) == "Z":
+            continue
+        pids.append(pid)
+    return pids
+
+
+def _pgrep_first_pid(pattern: str) -> int | None:
+    pids = _pgrep_pids(pattern)
+    return pids[0] if pids else None
+
+
+def _reap_children() -> int:
+    """Non-blocking `waitpid(-1, WNOHANG)` loop. Returns the number of reaped PIDs.
+
+    The bridge runs as PID 1 inside the container; daemonized ST processes
+    that exit reparent to it and stay zombie until `wait()`-ed for. Called
+    after `pkill -KILL` in `restart_st` so subsequent `pgrep` reads see
+    them as gone.
+    """
+    reaped = 0
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return reaped
+        except OSError:
+            return reaped
+        if pid == 0:
+            return reaped
+        reaped += 1
+
+
+def _probe_plugin_http() -> dict:
+    """Single 1.0 s `ping` POST to the plugin's HTTP server."""
+    payload = json.dumps(
+        {"jsonrpc": "2.0", "id": "bridge-inspect", "method": "ping"}
+    ).encode("utf-8")
+    started = time.monotonic()
+    try:
+        status, _ = http_post(ENDPOINT_URL, payload, timeout=1.0)
+    except (urllib.error.URLError, ConnectionError, OSError) as exc:
+        return {
+            "http_server_listening": False,
+            "http_probe_elapsed_s": round(time.monotonic() - started, 3),
+            "http_probe_error": repr(exc),
+        }
+    return {
+        "http_server_listening": status == 200,
+        "http_probe_elapsed_s": round(time.monotonic() - started, 3),
+        "http_probe_error": None if status == 200 else "HTTP %d" % status,
+    }
+
+
+def _xdpyinfo_ok() -> bool:
+    try:
+        result = subprocess.run(
+            ["xdpyinfo"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2.0,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return False
+    return result.returncode == 0
+
+
+def _xwininfo_tree(byte_cap: int = 2048) -> str | None:
+    try:
+        result = subprocess.run(
+            ["xwininfo", "-root", "-tree"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError):
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout
+    if len(out) > byte_cap:
+        return out[:byte_cap] + "\n…(truncated)"
+    return out
+
+
+def _uptime_s() -> int:
+    if _BRIDGE_STARTUP_MONOTONIC is None:
+        return 0
+    return int(time.monotonic() - _BRIDGE_STARTUP_MONOTONIC)
+
+
+def _run_inspect_environment(_args: dict) -> dict:
+    """Worker-thread-only snapshot of container-level state.
+
+    Best-effort: any individual subprocess failure surfaces as `None` /
+    `False` for that field; the rest of the payload still returns. Never
+    raises so the caller always gets *something* to read.
+    """
+    payload: dict = {
+        "bridge_pid": os.getpid(),
+        "sublime_text_pids": _pgrep_pids("sublime_text"),
+        "plugin_host_pid": _pgrep_first_pid("plugin_host"),
+        "xvfb_pid": _pgrep_first_pid("Xvfb"),
+    }
+    payload.update(_probe_plugin_http())
+    payload["display_reachable"] = _xdpyinfo_ok()
+    payload["x_windows"] = _xwininfo_tree()
+    payload["container_id"] = os.environ.get("HOSTNAME") or None
+    payload["workspace_path"] = WORKSPACE_PATH
+    payload["uptime_s"] = _uptime_s()
+    logger.info(
+        "inspect_environment st_pids=%s plugin_host=%s http=%s display=%s",
+        payload["sublime_text_pids"],
+        payload["plugin_host_pid"],
+        payload["http_server_listening"],
+        payload["display_reachable"],
+    )
+    return payload
+
+
+def _wait_until_processes_gone(pattern: str, timeout_s: float) -> float | None:
+    """Poll until no live (non-zombie) match remains. Return elapsed seconds, or None on timeout.
+
+    Reaps zombies on every iteration so processes that exited but stayed
+    listed as defunct (because the bridge is PID 1 and hasn't `wait()`-ed
+    for them) clear out without an explicit reap step. The state-character
+    filter in `_pgrep_pids` means this is correct even when the reap
+    loop misses (a process whose parent isn't the bridge can still be a
+    zombie without being our child).
+    """
+    started = time.monotonic()
+    while time.monotonic() - started < timeout_s:
+        _reap_children()
+        if not _pgrep_pids(pattern):
+            return time.monotonic() - started
+        time.sleep(0.1)
+    return None
+
+
+def _restart_failure(
+    started: float,
+    error: str,
+    log_lines: list[str],
+    before_st: list[int],
+    before_plugin: int | None,
+) -> dict:
+    return {
+        "success": False,
+        "elapsed_s": round(time.monotonic() - started, 3),
+        "error": error,
+        "sublime_text_pids_before": before_st,
+        "sublime_text_pids_after": _pgrep_pids("sublime_text"),
+        "plugin_host_pid_before": before_plugin,
+        "plugin_host_pid_after": _pgrep_first_pid("plugin_host"),
+        "http_ready_after_s": None,
+        "log_lines": log_lines,
+    }
+
+
+def _run_restart_st(_args: dict) -> dict:
+    """Kill ST + plugin host, relaunch `subl --stay`, poll the plugin HTTP
+    server until it's responsive again. Last-resort recovery when
+    `health_check` reports a wedged main thread (#73 part 2).
+
+    TERM-then-KILL escalation: SIGTERM first, wait up to 5 s for graceful
+    exit, escalate to SIGKILL if still alive. Then `subl --stay` (which
+    self-daemonizes and the launcher exits), and `wait_for_ready`.
+    """
+    log_lines: list[str] = []
+    started = time.monotonic()
+
+    before_st = _pgrep_pids("sublime_text")
+    before_plugin = _pgrep_first_pid("plugin_host")
+    log_lines.append(
+        "before: sublime_text_pids=%s plugin_host_pid=%s" % (before_st, before_plugin)
+    )
+
+    if before_st:
+        try:
+            term = subprocess.run(
+                ["pkill", "-TERM", "-f", "sublime_text"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=2.0,
+            )
+            log_lines.append("pkill -TERM -f sublime_text rc=%d" % term.returncode)
+        except (subprocess.SubprocessError, FileNotFoundError) as exc:
+            return _restart_failure(
+                started, "pkill -TERM failed: %r" % exc, log_lines, before_st, before_plugin
+            )
+        graceful = _wait_until_processes_gone("sublime_text", 5.0)
+        if graceful is not None:
+            log_lines.append("ST exited gracefully after %.2fs" % graceful)
+        else:
+            log_lines.append("ST did not exit within 5s; escalating to KILL")
+            try:
+                kill = subprocess.run(
+                    ["pkill", "-KILL", "-f", "sublime_text"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=2.0,
+                )
+                log_lines.append("pkill -KILL -f sublime_text rc=%d" % kill.returncode)
+            except (subprocess.SubprocessError, FileNotFoundError) as exc:
+                return _restart_failure(
+                    started, "pkill -KILL failed: %r" % exc, log_lines, before_st, before_plugin
+                )
+            # Reap any zombies whose parent is the bridge (PID 1) so the
+            # subsequent pgrep doesn't list them as "still running".
+            reaped = _reap_children()
+            if reaped:
+                log_lines.append("reaped %d zombie children" % reaped)
+            forced = _wait_until_processes_gone("sublime_text", 3.0)
+            if forced is None:
+                return _restart_failure(
+                    started, "sublime_text still running after KILL+3s",
+                    log_lines, before_st, before_plugin,
+                )
+            log_lines.append("ST exited after KILL in %.2fs" % forced)
+    else:
+        log_lines.append("no sublime_text processes before restart; skipping kill")
+
+    workspace = WORKSPACE_PATH if os.path.isdir(WORKSPACE_PATH) else "/tmp"
+    try:
+        log_fh = open(SUBL_LOG_PATH, "ab")
+    except OSError as exc:
+        log_lines.append("could not open %s: %r — using DEVNULL" % (SUBL_LOG_PATH, exc))
+        log_fh = subprocess.DEVNULL  # type: ignore[assignment]
+    try:
+        try:
+            launcher = subprocess.Popen(
+                ["subl", "--stay", workspace],
+                stdout=log_fh,
+                stderr=subprocess.STDOUT if log_fh is not subprocess.DEVNULL else log_fh,
+                start_new_session=True,
+            )
+            log_lines.append(
+                "subl --stay %s launched (launcher_pid=%d)" % (workspace, launcher.pid)
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            return _restart_failure(
+                started, "subl launch failed: %r" % exc, log_lines, before_st, before_plugin
+            )
+    finally:
+        if hasattr(log_fh, "close"):
+            try:
+                log_fh.close()
+            except Exception:
+                pass
+
+    # `subl --stay` self-daemonizes and the launcher exits within ~1 s. We
+    # wait briefly so log lines about "launcher pid" don't precede its exit.
+    try:
+        launcher.wait(timeout=10.0)
+        log_lines.append("subl launcher exited rc=%d" % launcher.returncode)
+    except subprocess.TimeoutExpired:
+        log_lines.append("warning: subl launcher did not exit within 10s")
+
+    deadline = time.monotonic() + RESTART_READY_TIMEOUT_S
+    ready_started = time.monotonic()
+    try:
+        wait_for_ready(deadline)
+    except RuntimeError as exc:
+        return _restart_failure(
+            started, "plugin HTTP did not come back: %s" % exc,
+            log_lines, before_st, before_plugin,
+        )
+    http_elapsed = time.monotonic() - ready_started
+    log_lines.append("plugin HTTP responsive after %.2fs (post-launch)" % http_elapsed)
+
+    after_st = _pgrep_pids("sublime_text")
+    after_plugin = _pgrep_first_pid("plugin_host")
+    log_lines.append(
+        "after: sublime_text_pids=%s plugin_host_pid=%s" % (after_st, after_plugin)
+    )
+
+    elapsed = time.monotonic() - started
+    logger.info(
+        "restart_st success elapsed=%.2fs plugin_host_pid=%s→%s",
+        elapsed, before_plugin, after_plugin,
+    )
+    return {
+        "success": True,
+        "elapsed_s": round(elapsed, 3),
+        "sublime_text_pids_before": before_st,
+        "sublime_text_pids_after": after_st,
+        "plugin_host_pid_before": before_plugin,
+        "plugin_host_pid_after": after_plugin,
+        "http_ready_after_s": round(http_elapsed, 3),
+        "log_lines": log_lines,
+    }
+
+
+_BRIDGE_TOOLS["inspect_environment"] = {
+    "descriptor": {
+        "name": "inspect_environment",
+        "description": (
+            "Bridge-owned diagnostic snapshot of container-level state — "
+            "process PIDs (Xvfb, sublime_text, plugin_host, bridge), "
+            "plugin HTTP reachability, X display reachability, top-level "
+            "X windows, container_id, workspace_path, uptime. Worker-"
+            "thread-only on the bridge: returns within ~3s even when ST's "
+            "main thread or the entire plugin host is unresponsive. Use "
+            "after `health_check` reports `main_thread_responsive: false` "
+            "to triage whether the plugin is alive at all and whether an "
+            "X dialog might be the cause; pair with `xdotool key Escape` "
+            "from an `exec_sublime_python` snippet for soft recovery, or "
+            "fall back to `restart_st` for hard recovery."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "handler": _run_inspect_environment,
+}
+
+_BRIDGE_TOOLS["restart_st"] = {
+    "descriptor": {
+        "name": "restart_st",
+        "description": (
+            "Last-resort in-agent recovery: kill the running Sublime Text "
+            "+ plugin host, relaunch `subl --stay <workspace>`, and poll "
+            "the plugin's HTTP server until it's responsive again. "
+            "TERM-then-KILL escalation (5s graceful budget). Returns "
+            "within ~30s with `success`, before/after PIDs, and a "
+            "`log_lines` array describing each step. Use after "
+            "`health_check` reports `main_thread_responsive: false` and "
+            "soft recovery (e.g. `xdotool key Escape` to dismiss an "
+            "invisible dialog) has not unblocked main. Destructive: open "
+            "views, scratch buffers, `temp_packages_link` registry state "
+            "do not survive — by design."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+    "handler": _run_restart_st,
+}
+
+
+def _bridge_tool_response(req_id: object, name: str, payload: dict) -> bytes:
+    text = json.dumps(payload, indent=2, default=str)
+    body = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "result": {
+            "content": [{"type": "text", "text": text}],
+            "isError": payload.get("success") is False,
+        },
+    }
+    return json.dumps(body).encode("utf-8")
+
+
+def _bridge_error_response(req_id: object, code: int, message: str) -> bytes:
+    body = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "error": {"code": code, "message": message},
+    }
+    return json.dumps(body).encode("utf-8")
+
+
+def _handle_bridge_tool_call(stripped: bytes) -> bytes:
+    """Dispatch a `tools/call` for a bridge-owned tool. Returns response bytes."""
+    body = json.loads(stripped.decode("utf-8"))
+    req_id = body.get("id")
+    params = body.get("params") or {}
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+    if not isinstance(arguments, dict):
+        return _bridge_error_response(req_id, -32602, "arguments must be an object")
+    spec = _BRIDGE_TOOLS.get(name)
+    if spec is None:  # pragma: no cover — guarded by caller
+        return _bridge_error_response(req_id, -32602, "unknown bridge tool: %s" % name)
+    try:
+        payload = spec["handler"](arguments)
+    except Exception as exc:
+        logger.exception("bridge tool %s raised", name)
+        return _bridge_error_response(req_id, -32603, "%s raised: %r" % (name, exc))
+    return _bridge_tool_response(req_id, name, payload)
+
+
+def _inject_bridge_tools_into_list(raw: bytes) -> bytes:
+    """Append bridge-owned descriptors to a `tools/list` response. Pass-through on parse failure."""
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        logger.warning("could not parse tools/list response; passing through unmodified")
+        return raw
+    if not isinstance(body, dict):
+        return raw
+    result = body.get("result")
+    if not isinstance(result, dict):
+        return raw
+    tools = result.get("tools")
+    if not isinstance(tools, list):
+        return raw
+    existing = {t.get("name") for t in tools if isinstance(t, dict)}
+    for name, spec in _BRIDGE_TOOLS.items():
+        if name not in existing:
+            tools.append(spec["descriptor"])
+    return json.dumps(body).encode("utf-8")
+
+
+def _forward_to_plugin(stripped: bytes) -> tuple[int, bytes] | None:
+    """Forward `stripped` to the plugin's HTTP server. Returns (status, body) or None on transport error."""
+    try:
+        return http_post(ENDPOINT_URL, stripped, timeout=PROXY_HTTP_TIMEOUT_S)
+    except (urllib.error.URLError, ConnectionError, OSError) as exc:
+        logger.warning("plugin HTTP error: %r", exc)
+        return None
+
+
+def _emit(stdout, raw: bytes) -> None:
+    stdout.write(raw)
+    if not raw.endswith(b"\n"):
+        stdout.write(b"\n")
+    stdout.flush()
+
+
 def proxy_loop() -> None:
     stdout = sys.stdout.buffer
     q: queue.Queue = queue.Queue()
@@ -193,18 +693,24 @@ def proxy_loop() -> None:
         stripped = item.strip()
         if not stripped:
             continue
-        req_id, method = _peek_request(stripped)
+        req_id, method, tool_name = _peek_request(stripped)
         _thread_local.request_id = req_id or "-"
         try:
-            logger.debug("forwarding method=%s bytes=%d", method, len(stripped))
-            try:
-                status, raw = http_post(ENDPOINT_URL, stripped, timeout=PROXY_HTTP_TIMEOUT_S)
-            except (urllib.error.URLError, ConnectionError, OSError) as exc:
-                logger.warning("plugin HTTP error: %r", exc)
-                err = _make_error_response(stripped, "plugin HTTP error: %r" % exc)
-                stdout.write(err + b"\n")
-                stdout.flush()
+            # 1. Bridge-owned tools: handle locally, never forward.
+            if method == "tools/call" and tool_name in _BRIDGE_TOOLS:
+                logger.info("dispatching bridge tool name=%s", tool_name)
+                response = _handle_bridge_tool_call(stripped)
+                _emit(stdout, response)
                 continue
+
+            # 2. Everything else: forward to the plugin.
+            logger.debug("forwarding method=%s bytes=%d", method, len(stripped))
+            forwarded = _forward_to_plugin(stripped)
+            if forwarded is None:
+                err = _make_error_response(stripped, "plugin HTTP transport error")
+                _emit(stdout, err)
+                continue
+            status, raw = forwarded
             if status == 202 or not raw:
                 logger.debug("received status=%d (notification, no body)", status)
                 continue
@@ -218,19 +724,22 @@ def proxy_loop() -> None:
                     stripped,
                     "plugin returned HTTP %d: %s" % (status, raw[:200].decode("utf-8", "replace")),
                 )
-                stdout.write(err + b"\n")
-                stdout.flush()
+                _emit(stdout, err)
                 continue
+
+            # 3. tools/list: inject bridge-owned descriptors before emitting.
+            if method == "tools/list":
+                raw = _inject_bridge_tools_into_list(raw)
+
             logger.debug("received status=%d bytes=%d", status, len(raw))
-            stdout.write(raw)
-            if not raw.endswith(b"\n"):
-                stdout.write(b"\n")
-            stdout.flush()
+            _emit(stdout, raw)
         finally:
             _thread_local.request_id = "-"
 
 
 def main() -> int:
+    global _BRIDGE_STARTUP_MONOTONIC
+    _BRIDGE_STARTUP_MONOTONIC = time.monotonic()
     level = os.environ.get("SUBLIME_MCP_LOG_LEVEL", "INFO").upper()
     if level not in LOG_LEVELS:
         level = "INFO"

--- a/skills/sublime-mcp/SKILL.md
+++ b/skills/sublime-mcp/SKILL.md
@@ -147,17 +147,128 @@ For the full helper surface, threading guarantees, and the authoritative `text_p
 { "main_thread_responsive": true, "main_thread_probe_elapsed_s": 0.01, "plugin_host_pid": 2060, "uptime_s": 142, "container_id": "<docker cid>", "workspace_path": "/work", "st_version": 4200, "st_channel": "stable" }
 ```
 
-**Call pattern.** When an `exec_sublime_python` call times out at 60s on something that touched the main thread (`scope_at`, `find_resources`, `open_file`, `assign_syntax_and_wait`, anything wrapped in `run_on_main`), call `health_check` *before* the next main-thread snippet. If `main_thread_responsive` is `false`, stop issuing main-thread snippets — every one will burn another 60s. Ask the user to restart the container; do not retry. If `main_thread_responsive` is `true`, the previous timeout was about that specific snippet, not a session-wide wedge — retrying is fine.
+**Call pattern.** When an `exec_sublime_python` call times out at 60s on something that touched the main thread (`scope_at`, `find_resources`, `open_file`, `assign_syntax_and_wait`, anything wrapped in `run_on_main`), call `health_check` *before* the next main-thread snippet. If `main_thread_responsive` is `false`, stop issuing main-thread snippets — every one will burn another 60s. Drive the recovery flow in §4 *Recover from a wedged main thread* rather than retrying. If `main_thread_responsive` is `true`, the previous timeout was about that specific snippet, not a session-wide wedge — retrying is fine.
 
-**`/mcp` reconnect does not clear a wedged main thread.** Per #73 (2026-05-05): the slash-command reports `Reconnected to sublime-text.` and re-establishes the MCP transport, but the underlying ST process keeps running with the same wedged main thread — the next `set_timeout(callback, 0); event.wait(...)` still returns False. Recovery requires a true container restart (use the `container_id` from a previous response: `docker kill <cid>`), then re-connect. Don't read "Reconnected" as "wedge cleared."
+**`/mcp` reconnect does not clear a wedged main thread.** Per #73 (2026-05-05): the slash-command reports `Reconnected to sublime-text.` and re-establishes the MCP transport, but the underlying ST process keeps running with the same wedged main thread — the next `set_timeout(callback, 0); event.wait(...)` still returns False. In-agent recovery is `restart_st` (§3.4); the docker-kill route (use the `container_id` from a previous response: `docker kill <cid>`) remains as a final fallback. Don't read "Reconnected" as "wedge cleared."
 
 **`/mcp` reconnect can also land on stale transport.** A `Reconnected to sublime-text.` message does not guarantee the transport has re-bound to the new container. If the next call returns `ConnectionRefusedError(61)`, the transport is still pointed at the previous container's stdio — dismiss `/mcp` and re-open (not just re-trigger) to force a re-bind. Independent of the wedge surface above: the stale-transport shape fires whenever the previous container went away (wedge recovery via `docker kill`, container OOM, container restart) and Claude Code's reconnect attempt landed before the new container was discoverable (#104). Guard pattern: after `docker kill` + reconnect, fire a single `health_check`; on `ConnectionRefusedError`, the user needs to re-open `/mcp` rather than the agent retrying.
+
+### 3.3 inspect_environment
+
+`mcp__sublime-text__inspect_environment({})` is a bridge-owned diagnostic snapshot of container-level state. Worker-thread-only on the bridge — never touches the plugin host — so it returns within ~3s even when ST main is wedged or the entire plugin host is dead. Response shape:
+
+```json
+{
+  "bridge_pid": 1,
+  "sublime_text_pids": [42],
+  "plugin_host_pid": 56,
+  "xvfb_pid": 18,
+  "http_server_listening": true,
+  "http_probe_elapsed_s": 0.05,
+  "http_probe_error": null,
+  "display_reachable": true,
+  "x_windows": "<xwininfo -root -tree, capped at ~2KB>",
+  "container_id": "<docker cid>",
+  "workspace_path": "/work",
+  "uptime_s": 142
+}
+```
+
+**Call pattern.** Use after `health_check` returns `main_thread_responsive: false` to triage *which* recovery to attempt. Read it as a decision tree:
+
+- `http_server_listening: false` → plugin host is dead (not just wedged). `health_check` would also be unreachable. Go straight to `restart_st` (§3.4).
+- `http_server_listening: true` and unexpected entries in `x_windows` (a dialog title that isn't ST's main editor window) → soft recovery first: `subprocess.run(["xdotool", "key", "Escape"], capture_output=True, timeout=5)` from an `exec_sublime_python` snippet, then `health_check` again. If main is back, continue.
+- `http_server_listening: true` and `x_windows` looks normal → wedge isn't dialog-shaped; soft recovery won't help. Use `restart_st`.
+- `display_reachable: false` → Xvfb itself is gone. `restart_st` won't help (it relaunches `subl --stay` against a missing display); ask the user to restart the container.
+
+Best-effort: any individual subprocess failure surfaces as `null` / `false` for that field; the rest of the payload still returns. The tool never raises — read each field independently.
+
+### 3.4 restart_st
+
+`mcp__sublime-text__restart_st({})` is the in-agent escape hatch for a wedge that soft recovery (§3.5 `xdotool`) doesn't clear. Bridge-owned: kills ST + plugin host (TERM, then KILL after 5s), relaunches `subl --stay <workspace>`, polls until the plugin's HTTP server is responsive again. Returns within ~30s. Response shape:
+
+```json
+{
+  "success": true,
+  "elapsed_s": 8.3,
+  "sublime_text_pids_before": [42],
+  "sublime_text_pids_after": [161],
+  "plugin_host_pid_before": 56,
+  "plugin_host_pid_after": 187,
+  "http_ready_after_s": 6.1,
+  "log_lines": ["…", "…"]
+}
+```
+
+**On success.** The new plugin host is fully reinitialised — `plugin_loaded()` ran, `health_check` should return `main_thread_responsive: true` immediately, and `exec_sublime_python` round-trips work again. Re-issue the original probe. `plugin_host_pid_before != plugin_host_pid_after` is the in-payload signal that the restart actually cycled the process.
+
+**On failure.** `success: false`, `error` carries a short message, `log_lines` shows which step got through. Common shapes:
+
+- `"sublime_text still running after KILL+3s"` — process is unkillable from PID 1's perspective (rare; typically a kernel-level zombie). Ask the user to `docker kill <cid>`.
+- `"plugin HTTP did not come back: ..."` — `subl --stay` was launched but the plugin host never started its HTTP server within 30s. Either the relaunch silently bounced off a startup dialog (check `x_windows` via `inspect_environment`) or ST hit a worse failure mode. Ask the user to `docker kill <cid>`.
+- `"subl launch failed: ..."` — `subl` binary is unavailable. Container-image bug; file an issue.
+
+**Destructive — does not preserve view state.** Open files, scratch buffers, the in-memory `_TEMP_LINKS` registry from `temp_packages_link` calls are all gone after the restart. Symlinks under `Packages/__sublime_mcp_temp_*` are reaped by the next helper invocation's lazy sweep. Don't reach for `restart_st` for ergonomics — only when a wedge is the real cause.
+
+### 3.5 X-debug binaries (`xdotool`, `xdpyinfo`, `xwininfo`, `xprop`, `xkill`)
+
+The image ships these stable Ubuntu utilities for inspecting / interacting with the Xvfb display from inside the container (#75). All are callable from `subprocess.run([...], capture_output=True, timeout=...)` inside `exec_sublime_python` — they execute on the worker thread, so they keep working when ST main is wedged.
+
+- `xdotool key Escape` / `xdotool key Return` — synthesise key events; the soft-recovery workhorse for invisible startup or modal dialogs that ST's headless build can't dismiss on its own.
+- `xdpyinfo` (exit code) — quick "is the X display reachable?" probe. Already wrapped in `inspect_environment.display_reachable`.
+- `xwininfo -root -tree` — enumerate top-level windows. Already wrapped in `inspect_environment.x_windows`; reach for it directly if you need more than the truncated 2KB snapshot.
+- `xprop -id <id>` — read window properties (`WM_CLASS`, `WM_NAME`) once a suspect window's id is known.
+- `xkill` — last-resort window kill via X protocol, before reaching for `restart_st`.
+
+Usage example (from a snippet, after `inspect_environment` flagged a candidate dialog):
+
+```python
+import subprocess
+r = subprocess.run(
+    ["xdotool", "search", "--name", ".*", "key", "Escape"],
+    capture_output=True, text=True, timeout=5,
+)
+print(r.returncode, r.stderr[:200])
+```
+
+These binaries are not on the agent's MCP surface — they're shell tools, used through `exec_sublime_python`. The bridge wrappers in §3.3 cover the common diagnostic shape.
 
 ## 4. Recipes
 
 Each recipe is one `exec_sublime_python` call. Rows and columns are **0-indexed** — a test-file assertion on line 181 col 9 is `row=180, col=8`. Paths shown are container-side; the user typically mounts their working tree at `/work`.
 
 **Host-side file-write tools.** If you're driving this skill from an agent harness with its own host-side write tool (Claude Code's `Write`, Cursor's edit tool, anything similar), don't pre-write probe files to host paths and then pass those paths into `exec_sublime_python` helpers. The container only sees paths under `--mount` directories (typically `/work`) plus its own `/tmp`; anything else is invisible regardless of how the path looks on the host. The failure shape is a hang or indexer-budget timeout (the #67 / #73 surfaces), not a clean `FileNotFoundError`. Write probe files inside the snippet instead — see *Probe a synthetic case inline* and *Probe a synthetic syntax against a synthetic input* below.
+
+### Recover from a wedged main thread
+
+When `health_check` returns `main_thread_responsive: false`, walk this escalation rather than retrying main-thread snippets (every retry burns another 60s on the wedged path). The flow goes from cheapest signal to most disruptive recovery; stop at the first step that puts main back.
+
+1. **`inspect_environment`** to triage. Read `http_server_listening`, `display_reachable`, and `x_windows`:
+   - `http_server_listening: false` → plugin host is dead. Skip to step 4.
+   - `http_server_listening: true` and `x_windows` lists an unexpected window (anything not the ST editor) → likely an invisible dialog blocking main. Try step 2.
+   - `http_server_listening: true` and `x_windows` looks normal → wedge isn't dialog-shaped. Skip to step 4.
+   - `display_reachable: false` → Xvfb is gone; restart can't help. Skip to step 5.
+
+2. **Soft recovery via `xdotool`.** From an `exec_sublime_python` snippet, dismiss the dialog and check whether main came back:
+
+   ```python
+   import subprocess
+   r = subprocess.run(
+       ["xdotool", "key", "--clearmodifiers", "Escape"],
+       capture_output=True, text=True, timeout=5,
+   )
+   print(r.returncode, r.stderr[:200])
+   ```
+
+   Then call `health_check` again. If `main_thread_responsive: true`, you're done — re-issue the probe that timed out. If still wedged, try `xdotool key Return` (some dialogs only accept the default action), then re-check.
+
+3. **`xkill`-style escalation** is rarely worth the round-trip — if Escape and Return don't dismiss, jump to step 4 instead.
+
+4. **`restart_st`** for hard recovery. Returns within ~30s with `success: true` and a fresh `plugin_host_pid_after`. After success, `health_check` should return `main_thread_responsive: true` immediately. Re-issue the original probe. Open files, scratch buffers, and the in-memory `_TEMP_LINKS` registry are gone — by design.
+
+5. **`docker kill <cid>` (final fallback).** When `restart_st` returns `success: false` (process unkillable, plugin HTTP never re-bound, etc.), surface the `container_id` (from any prior response) and ask the user to `docker kill <cid>`. They re-trigger `/mcp` (re-open, not just reconnect — see §3.2 stale-transport note); the harness shim spawns a fresh container.
+
+Don't skip step 1 — guessing at the cause without `inspect_environment` wastes turns: a soft-recovery attempt against a dead plugin host doesn't help, and a `restart_st` against a working plugin host whose only problem is a dialog is unnecessarily disruptive.
 
 ### Scope at a position
 
@@ -418,9 +529,10 @@ _ = results
 
 ## 6. Known limitations / tracking
 
-_Last synced with issue state: 2026-05-06._
+_Last synced with issue state: 2026-05-07._
 
 - **Log levels are part of the contract; log line format is best-effort.** The four-level meaning (ERROR / WARNING / INFO / DEBUG) and the column positions of `req=<id>` are stable within a release line. The exact wording of individual messages and their phrasing may change between releases.
+- **#73 / #75 — wedge recovery toolkit.** Closed: detection (`health_check`, §3.2), bridge-side diagnosis (`inspect_environment`, §3.3), in-agent recovery (`restart_st`, §3.4), and the X-debug binaries the image now ships (`xdotool`, `x11-utils`, §3.5). The escalation flow lives at §4 *Recover from a wedged main thread*. Out-of-scope follow-ups (separate tickets when needed): preserving view state across `restart_st`, diagnosing *why* ST wedged in the first place, the `install.md` "restart the agent session" recipe correction.
 - **Parse-table-build silent fallback (case-3 of three).** ST sometimes registers a syntax structurally — `sublime.list_syntaxes()` shows it with the declared scope, `view.syntax().path` echoes the requested URI — but its parse-table builder rejects something deeper (e.g. an action shape ST doesn't compile, like multi-target `embed: [a, b]`), or a `push: scope:` / `embed: scope:` / `include: scope:` against an unresolvable target falls back to Plain Text inside the embedded frame. The `requested == resolved` invariant from §7 does not catch either shape. `probe_scopes` raises `RuntimeError` from a sweep-time detector that runs after the committed sweep output is in hand (post-#107 fix — the earlier point-0-only detector misfired ~25 % of the time when ST tokenisation raced the warm-up). Two shapes flagged: (a) every position bare `text.plain` under a non-plain declared base — the single-syntax variant from #78 widened to the full sweep (#107); (b) any position carrying `text.plain` as a non-leading scope element — the embed-side variant where a cross-syntax reference fell back to Plain Text whose `meta_scope` is `text.plain` (#109). For the single-position helpers (`scope_at_test`, `resolve_position`), the dict-level detection is `resolved_syntax != "Packages/Text/Plain text.tmLanguage"` AND `scope == "text.plain"` AND `sublime.syntax_from_path(resolved).scope` is non-plain — they can't construct the cross-position view (b) relies on, so their detector stays at the assigned-syntax level.
 - **#7** — parameterise the test suite's hardcoded `HEADER` across syntaxes.
 - **#8** — concurrency cap on the exec daemon-thread pool.

--- a/tests/test_image_smoke.py
+++ b/tests/test_image_smoke.py
@@ -125,7 +125,80 @@ def run() -> int:
         output = (outcome.get("output") or "").strip()
         assert output.isdigit(), outcome
         assert int(output) >= 4000, outcome  # ST 4 build
-        print("PASS: image round-trips, ST build %s" % output)
+
+        # tools/list — bridge injects inspect_environment + restart_st
+        # alongside the plugin-owned exec_sublime_python + health_check.
+        _send(proc, {"jsonrpc": "2.0", "id": 3, "method": "tools/list"})
+        resp = _recv(proc, timeout_s=10.0)
+        assert resp.get("id") == 3, resp
+        tools = resp.get("result", {}).get("tools") or []
+        names = {t.get("name") for t in tools}
+        for required in ("exec_sublime_python", "health_check",
+                         "inspect_environment", "restart_st"):
+            assert required in names, (required, names)
+
+        # inspect_environment — bridge-owned, runs even with ST main wedged.
+        # Healthy container should report the plugin HTTP server listening
+        # and Xvfb reachable.
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {"name": "inspect_environment", "arguments": {}},
+        })
+        resp = _recv(proc, timeout_s=10.0)
+        assert resp.get("id") == 4, resp
+        content = resp.get("result", {}).get("content") or []
+        assert content and content[0].get("type") == "text", resp
+        env = json.loads(content[0]["text"])
+        for key in ("bridge_pid", "sublime_text_pids", "plugin_host_pid",
+                    "xvfb_pid", "http_server_listening", "display_reachable",
+                    "x_windows", "container_id", "workspace_path", "uptime_s"):
+            assert key in env, (key, env)
+        assert env["http_server_listening"] is True, env
+        assert env["display_reachable"] is True, env
+        assert env["sublime_text_pids"], env
+        plugin_host_before = env["plugin_host_pid"]
+        assert plugin_host_before is not None, env
+
+        # restart_st — kills ST + plugin host, relaunches subl --stay,
+        # waits for the HTTP server to come back. Gives ~60 s for the
+        # 30 s-timeout primitive plus margin for slow CI runners.
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 5,
+            "method": "tools/call",
+            "params": {"name": "restart_st", "arguments": {}},
+        })
+        resp = _recv(proc, timeout_s=60.0)
+        assert resp.get("id") == 5, resp
+        content = resp.get("result", {}).get("content") or []
+        assert content and content[0].get("type") == "text", resp
+        restart = json.loads(content[0]["text"])
+        assert restart.get("success") is True, restart
+        assert restart.get("plugin_host_pid_after") is not None, restart
+        assert restart["plugin_host_pid_after"] != plugin_host_before, restart
+
+        # Round-trip a trivial snippet against the rebuilt ST.
+        _send(proc, {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tools/call",
+            "params": {
+                "name": "exec_sublime_python",
+                "arguments": {"code": "print(sublime.version())"},
+            },
+        })
+        resp = _recv(proc, timeout_s=30.0)
+        assert resp.get("id") == 6, resp
+        content = resp.get("result", {}).get("content") or []
+        outcome = json.loads(content[0]["text"])
+        output = (outcome.get("output") or "").strip()
+        assert output.isdigit() and int(output) >= 4000, outcome
+
+        print("PASS: image round-trips, ST build %s, restart_st cycles plugin host (%s -> %s)" % (
+            output, plugin_host_before, restart["plugin_host_pid_after"],
+        ))
         return 0
     finally:
         if proc.poll() is None:


### PR DESCRIPTION
Closes #73. Closes #75. Adds the layered toolkit between `health_check` (detection, #85) and "ask the user to `docker kill`": one bridge-owned diagnostic surface, one in-agent recovery primitive, and the X-side inspection binaries that were missing from the image.

`inspect_environment` (worker-thread-only on the bridge) reports container-level state — process PIDs, plugin HTTP reachability, X display reachability, top-level X windows, container_id — within ~3 s even when ST main is wedged or the entire plugin host is unreachable. `restart_st` is the last-resort escape hatch: TERM-then-KILL-after-5 s on `sublime_text`, relaunch via `subl --stay <workspace>`, poll `wait_for_ready` until the plugin's HTTP server is back. Both live in `bridge.py`; `proxy_loop` is refactored into a dispatcher that intercepts `tools/list` (injects bridge-owned descriptors) and `tools/call` for bridge-owned names. Initial smoke-test run caught a real bug — the bridge runs as PID 1 inside the container and didn't reap defunct ST children, so post-KILL `pgrep` listed zombies as "still running"; fixed via `_reap_children` (`waitpid(-1, WNOHANG)`) and a `/proc/N/stat` state-character filter in `_pgrep_pids`.

`xdotool` + `x11-utils` (Dockerfile, <5 MB combined) make X-side wedge inspection possible from existing `exec_sublime_python` snippets — `xdpyinfo` and `xwininfo` also back the corresponding fields in `inspect_environment`.

`skills/sublime-mcp/SKILL.md` documents the new tools (§3.3 `inspect_environment`, §3.4 `restart_st`, §3.5 X-debug binaries) and a §4 *Recover from a wedged main thread* recipe walking the inspect → soft-via-`xdotool` → `restart_st` → `docker kill` escalation. §6 closes out #73 / #75.

## Test plan

- [x] `tests/test_image_smoke.py` extended: asserts `tools/list` carries the four expected names, validates the `inspect_environment` payload shape on a healthy container, and exercises `restart_st` end-to-end (`success: true`, `plugin_host_pid_after != plugin_host_pid_before`, post-restart `exec_sublime_python` round-trips).
- [x] Local image-smoke passes deterministically: `restart_st` cycles plugin host in ~0.5 s; round-trip after restart returns ST build 4200.
- [x] `xdotool --version` / `xdpyinfo -version` / `xwininfo -version` / `xprop -version` all resolve inside the rebuilt image.
